### PR TITLE
fix: PTT no audio on receive — audio session + playback bugs (#32)

### DIFF
--- a/SMOKE_TEST.md
+++ b/SMOKE_TEST.md
@@ -11,7 +11,11 @@ Argus gate: if a PR or release does not include a completed smoke test section �
 ### Intercom
 - [ ] Open Intercom tab → status shows **"Connected to group intercom"** within 5s (never stuck on "Connecting...")
 - [ ] PTT button is **enabled and tappable** (not greyed out)
-- [ ] Hold PTT on Phone A → Phone B hears voice audio within ~2s
+- [ ] Hold PTT on Phone A for ~1s (short) → **Phone B hears audio clearly** within ~2s
+- [ ] Hold PTT on Phone A for ~5s (long message) → Phone B hears full audio, not cut off
+- [ ] Phone B speaks back → Phone A hears it (bidirectional, both directions must work)
+- [ ] iOS → Android: Phone A (iOS) speaks → Phone B (Android) hears it
+- [ ] Android → iOS: Phone A (Android) speaks → Phone B (iOS) hears it
 - [ ] Release PTT → channel shows clear, "Now Talking" resets
 
 ### iPod / AirPod
@@ -41,6 +45,7 @@ Argus gate: if a PR or release does not include a completed smoke test section �
 - [ ] Fresh install (no cached data) → no crash on first launch
 - [ ] AirPods connected → intercom audio routes through earphones correctly
 - [ ] Two-phone full round-trip: both users can PTT and hear each other bidirectionally
+- [ ] Audio quality acceptable at both short (~1s) and long (~10s) message durations
 
 ---
 

--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -89,16 +89,28 @@ const IntercomScreen = () => {
         await FileSystem.writeAsStringAsync(tempFile, base64Data, {
           encoding: FileSystem.EncodingType.Base64
         });
-        const { sound } = await Audio.Sound.createAsync({ uri: tempFile }, { shouldPlay: false });
+        // Switch audio session to playback mode before playing
+        await Audio.setAudioModeAsync({
+          allowsRecordingIOS: false,
+          playsInSilentModeIOS: true,
+          interruptionModeIOS: InterruptionModeIOS.DoNotMix,
+          interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
+          shouldDuckAndroid: true,
+          playThroughEarpieceAndroid: false,
+          staysActiveInBackground: false,
+        });
+        const { sound } = await Audio.Sound.createAsync(
+          { uri: tempFile },
+          { shouldPlay: true }  // play immediately on load
+        );
         await new Promise<void>((resolve) => {
           sound.setOnPlaybackStatusUpdate((status) => {
             if (!status.isLoaded) return;
-            if (status.didJustFinish || !status.isPlaying) {
+            if (status.didJustFinish) {  // only resolve when actually finished
               sound.setOnPlaybackStatusUpdate(null);
               resolve();
             }
           });
-          sound.playAsync();
         });
         await sound.unloadAsync();
       } catch (error) {
@@ -224,7 +236,32 @@ const IntercomScreen = () => {
       });
 
       const recording = new Audio.Recording();
-      await recording.prepareToRecordAsync(Audio.RecordingOptionsPresets.HIGH_QUALITY);
+      await recording.prepareToRecordAsync({
+        isMeteringEnabled: false,
+        android: {
+          extension: '.aac',
+          outputFormat: Audio.AndroidOutputFormat.AAC_ADTS,
+          audioEncoder: Audio.AndroidAudioEncoder.AAC,
+          sampleRate: 16000,
+          numberOfChannels: 1,
+          bitRate: 32000,
+        },
+        ios: {
+          extension: '.aac',
+          outputFormat: Audio.IOSOutputFormat.MPEG4AAC,
+          audioQuality: Audio.IOSAudioQuality.MEDIUM,
+          sampleRate: 16000,
+          numberOfChannels: 1,
+          bitRate: 32000,
+          linearPCMBitDepth: 16,
+          linearPCMIsBigEndian: false,
+          linearPCMIsFloat: false,
+        },
+        web: {
+          mimeType: 'audio/webm',
+          bitsPerSecond: 32000,
+        },
+      });
       await recording.startAsync();
       recordingRef.current = recording;
       setIsRecording(true);
@@ -271,6 +308,16 @@ const IntercomScreen = () => {
     } finally {
       recordingRef.current = null;
       setIsRecording(false);
+      // Restore audio session to playback mode so incoming audio can be heard
+      Audio.setAudioModeAsync({
+        allowsRecordingIOS: false,
+        playsInSilentModeIOS: true,
+        interruptionModeIOS: InterruptionModeIOS.DoNotMix,
+        interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
+        shouldDuckAndroid: true,
+        playThroughEarpieceAndroid: false,
+        staysActiveInBackground: false,
+      }).catch(() => null);
       wsClient.send({ type: 'ptt_end' });
       if (userId) {
         setMembers((prev) => {


### PR DESCRIPTION
Fixes #32

## 3 bugs fixed

**Bug 1 — Sound unloaded before it plays**
`shouldPlay: false` + resolving on `!status.isPlaying` fired before audio started. Fixed: `shouldPlay: true` on createAsync, resolve only on `didJustFinish`.

**Bug 2 — iOS audio session in record mode blocks playback**
`setAudioModeAsync` was only set for recording. The receiver's session was never switched to playback mode. Fixed: call `setAudioModeAsync({ allowsRecordingIOS: false })` before every playback.

**Bug 3 — Wrong recording format (iOS .caf, Android can't play)**
HIGH_QUALITY preset is .caf on iOS. Fixed: explicit MPEG4AAC/AAC_ADTS 16kHz mono 32kbps on both platforms.

**Bonus — Audio session not restored after recording**
After David speaks, his device stays in record mode. Daniel releases PTT and the session is never reset. Fixed: `setAudioModeAsync(allowsRecordingIOS: false)` in stopRecording finally block.

## Smoke Test
- [x] enqueuePlayback resolves only on didJustFinish (code verified)
- [x] setAudioModeAsync(allowsRecordingIOS: false) called before playback (code verified)
- [x] setAudioModeAsync(allowsRecordingIOS: false) called after recording stops (code verified)
- [x] Recording format: MPEG4AAC (iOS) + AAC_ADTS (Android) — cross-platform (code verified)
- [x] tsc --noEmit: zero errors
- [ ] David speaks → Daniel hears audio (physical device — pending testers)