### PR TITLE
feat: run tracking engine (#37)

### DIFF
--- a/backend/migrations/004_runs.sql
+++ b/backend/migrations/004_runs.sql
@@ -1,0 +1,30 @@
+-- Wooverse — Migration 004: Run Tracking Engine
+-- Adds runs table + altitude/speed columns to locations
+
+-- 1. Add altitude and speed to locations (may be NULL for legacy rows)
+ALTER TABLE locations
+  ADD COLUMN IF NOT EXISTS altitude_m NUMERIC(8, 2),
+  ADD COLUMN IF NOT EXISTS speed_kmh  NUMERIC(6, 2);
+
+-- 2. Runs table
+CREATE TABLE IF NOT EXISTS runs (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  group_id         UUID REFERENCES groups(id) ON DELETE SET NULL,
+  started_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ended_at         TIMESTAMPTZ,
+  duration_seconds INTEGER,
+  distance_meters  NUMERIC(10, 2),
+  vertical_meters  NUMERIC(8, 2),       -- positive = descent depth
+  max_speed_kmh    NUMERIC(6, 2),
+  avg_speed_kmh    NUMERIC(6, 2),
+  top_altitude_m   NUMERIC(8, 2),       -- altitude at run start
+  bottom_altitude_m NUMERIC(8, 2),      -- altitude at run end
+  status           TEXT NOT NULL DEFAULT 'active'
+                   CHECK (status IN ('active', 'completed', 'discarded')),
+  created_at       TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_user_id       ON runs(user_id);
+CREATE INDEX IF NOT EXISTS idx_runs_started_at    ON runs(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_runs_user_status   ON runs(user_id, status);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -9,6 +9,7 @@ const groupRoutes = require('./routes/groups');
 const locationRoutes = require('./routes/locations');
 const sosRoutes = require('./routes/sos');
 const adminRoutes = require('./routes/admin');
+const runRoutes = require('./routes/runs');
 
 const app = express();
 const server = http.createServer(app);
@@ -28,6 +29,7 @@ app.use('/api/groups', groupRoutes);
 app.use('/api/locations', locationRoutes);
 app.use('/api/sos', sosRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/runs', runRoutes);
 
 // WebSocket for real-time: GPS pings + intercom signaling
 setupWebSocket(server);

--- a/backend/src/routes/runs.js
+++ b/backend/src/routes/runs.js
@@ -1,0 +1,125 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../config/db');
+const { requireAuth } = require('../middleware/auth');
+
+// POST /api/runs/start — Open a new active run
+router.post('/start', requireAuth, async (req, res) => {
+  try {
+    const { group_id, top_altitude_m, started_at } = req.body;
+    const result = await pool.query(
+      `INSERT INTO runs (user_id, group_id, top_altitude_m, started_at, status)
+       VALUES ($1, $2, $3, $4, 'active')
+       RETURNING id`,
+      [req.user.userId, group_id || null, top_altitude_m || null, started_at || new Date()]
+    );
+    res.status(201).json({ run_id: result.rows[0].id });
+  } catch (err) {
+    console.error('[Runs] POST /start error:', err);
+    res.status(500).json({ error: 'Failed to start run' });
+  }
+});
+
+// POST /api/runs/:id/end — Close run with final stats
+router.post('/:id/end', requireAuth, async (req, res) => {
+  try {
+    const {
+      ended_at,
+      duration_seconds,
+      distance_meters,
+      vertical_meters,
+      max_speed_kmh,
+      avg_speed_kmh,
+      bottom_altitude_m
+    } = req.body;
+
+    const result = await pool.query(
+      `UPDATE runs SET
+         status = 'completed',
+         ended_at = $1,
+         duration_seconds = $2,
+         distance_meters = $3,
+         vertical_meters = $4,
+         max_speed_kmh = $5,
+         avg_speed_kmh = $6,
+         bottom_altitude_m = $7
+       WHERE id = $8 AND user_id = $9 AND status = 'active'
+       RETURNING id`,
+      [
+        ended_at || new Date(),
+        duration_seconds,
+        distance_meters,
+        vertical_meters,
+        max_speed_kmh,
+        avg_speed_kmh,
+        bottom_altitude_m || null,
+        req.params.id,
+        req.user.userId
+      ]
+    );
+
+    if (!result.rows.length) {
+      return res.status(404).json({ error: 'Run not found or already closed' });
+    }
+
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[Runs] POST /:id/end error:', err);
+    res.status(500).json({ error: 'Failed to end run' });
+  }
+});
+
+// POST /api/runs/:id/discard — Mark run as discarded
+router.post('/:id/discard', requireAuth, async (req, res) => {
+  try {
+    await pool.query(
+      `UPDATE runs SET status = 'discarded' WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.userId]
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[Runs] POST /:id/discard error:', err);
+    res.status(500).json({ error: 'Failed to discard run' });
+  }
+});
+
+// GET /api/runs — Paginated run history (completed only, newest first)
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit) || 20, 50);
+    const offset = parseInt(req.query.offset) || 0;
+    const result = await pool.query(
+      `SELECT id, started_at, ended_at, duration_seconds, distance_meters,
+              vertical_meters, max_speed_kmh, avg_speed_kmh,
+              top_altitude_m, bottom_altitude_m, status
+       FROM runs
+       WHERE user_id = $1 AND status = 'completed'
+       ORDER BY started_at DESC
+       LIMIT $2 OFFSET $3`,
+      [req.user.userId, limit, offset]
+    );
+    res.json({ runs: result.rows, offset, limit });
+  } catch (err) {
+    console.error('[Runs] GET / error:', err);
+    res.status(500).json({ error: 'Failed to fetch runs' });
+  }
+});
+
+// GET /api/runs/:id — Single run detail
+router.get('/:id', requireAuth, async (req, res) => {
+  try {
+    const result = await pool.query(
+      `SELECT * FROM runs WHERE id = $1 AND user_id = $2`,
+      [req.params.id, req.user.userId]
+    );
+    if (!result.rows.length) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error('[Runs] GET /:id error:', err);
+    res.status(500).json({ error: 'Failed to fetch run' });
+  }
+});
+
+module.exports = router;

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -66,10 +66,10 @@ const TabsLayout = () => {
         }}
       />
       <Tabs.Screen
-        name="ipod"
+        name="runs"
         options={{
-          title: 'iPod',
-          tabBarIcon: ({ color, size }) => <Ionicons name="headset-outline" color={color} size={size} />
+          title: 'Runs',
+          tabBarIcon: ({ color, size }) => <Ionicons name="speedometer-outline" color={color} size={size} />
         }}
       />
       <Tabs.Screen

--- a/frontend/app/(tabs)/map.tsx
+++ b/frontend/app/(tabs)/map.tsx
@@ -9,6 +9,7 @@ import {
   startLocationTracking,
   stopLocationTracking
 } from '../services/location';
+import runEngine, { RunSnapshot } from '../services/runEngine';
 import wsClient from '../services/ws';
 
 interface Teammate {
@@ -110,9 +111,28 @@ const MAP_HTML = `
 </html>
 `;
 
+const formatDuration = (s: number): string => {
+  const mins = Math.floor(s / 60);
+  const secs = s % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+};
+
+interface SummaryRowProps {
+  label: string;
+  value: string;
+}
+
+const SummaryRow = ({ label, value }: SummaryRowProps) => (
+  <View style={styles.summaryRow}>
+    <Text style={styles.summaryLabel}>{label}</Text>
+    <Text style={styles.summaryValue}>{value}</Text>
+  </View>
+);
+
 const MapScreen = () => {
   const [coords, setCoords] = useState<Coordinates | null>(null);
   const [groupId, setGroupId] = useState<string | null>(null);
+  const [runSnap, setRunSnap] = useState<RunSnapshot | null>(null);
   const [teammates, setTeammates] = useState<Teammate[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
@@ -184,9 +204,18 @@ const MapScreen = () => {
   }, []);
 
   useEffect(() => {
+    runEngine.onUpdate(setRunSnap);
+  }, []);
+
+  useEffect(() => {
     let mounted = true;
     startLocationTracking((latest) => {
-      if (mounted) setCoords(latest);
+      if (mounted) {
+        setCoords(latest);
+        runEngine.feed(latest, groupId).catch((err) =>
+          console.warn('[Map] runEngine.feed error:', err)
+        );
+      }
     }).catch((error) => {
       setLocationError(error.message || 'Location unavailable');
     });
@@ -194,7 +223,8 @@ const MapScreen = () => {
       mounted = false;
       stopLocationTracking();
     };
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId]);
 
   useEffect(() => {
     const handler = (message: any) => {
@@ -325,6 +355,26 @@ const MapScreen = () => {
         />
       </View>
 
+      {/* Run HUD overlay — shown during ACTIVE run */}
+      {runSnap?.state === 'ACTIVE' && (
+        <View style={styles.runHUD}>
+          <View style={styles.hudRow}>
+            <Text style={styles.hudLabel}>SPEED</Text>
+            <Text style={styles.hudValue}>{runSnap.maxSpeedKmh.toFixed(0)}</Text>
+            <Text style={styles.hudUnit}>km/h</Text>
+          </View>
+          <View style={styles.hudRow}>
+            <Text style={styles.hudLabel}>↓ DROP</Text>
+            <Text style={styles.hudValue}>{runSnap.verticalMeters.toFixed(0)}</Text>
+            <Text style={styles.hudUnit}>m</Text>
+          </View>
+          <View style={styles.hudRow}>
+            <Text style={styles.hudLabel}>TIME</Text>
+            <Text style={styles.hudValue}>{formatDuration(runSnap.durationSeconds)}</Text>
+          </View>
+        </View>
+      )}
+
       <View style={styles.sosWrapper}>
         <Pressable
           onLongPress={handleSosLongPress}
@@ -341,6 +391,35 @@ const MapScreen = () => {
         {sosSent ? <Text style={styles.sosStatusText}>SOS SENT</Text> : null}
       </View>
     </View>
+
+      {/* Post-run summary modal */}
+      <Modal
+        animationType="slide"
+        transparent
+        visible={runSnap?.state === 'ENDED'}
+        onRequestClose={() => {}}
+      >
+        <View style={styles.summaryBackdrop}>
+          <View style={styles.summaryCard}>
+            <Text style={styles.summaryTitle}>🎿 Run Complete!</Text>
+            {runSnap && (
+              <>
+                <SummaryRow label="Duration" value={formatDuration(runSnap.durationSeconds)} />
+                <SummaryRow label="Vertical" value={`${runSnap.verticalMeters.toFixed(0)} m`} />
+                <SummaryRow
+                  label="Distance"
+                  value={`${(runSnap.distanceMeters / 1000).toFixed(2)} km`}
+                />
+                <SummaryRow label="Top Speed" value={`${runSnap.maxSpeedKmh.toFixed(1)} km/h`} />
+                <SummaryRow label="Avg Speed" value={`${runSnap.avgSpeedKmh.toFixed(1)} km/h`} />
+              </>
+            )}
+            <Pressable style={styles.summaryDoneBtn} onPress={() => { /* runEngine auto-resets after 2 s */ }}>
+              <Text style={styles.summaryDoneBtnText}>Done</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
 
       <Modal
         animationType="fade"
@@ -407,7 +486,31 @@ const styles = StyleSheet.create({
   modalSubtitle: { color: '#ffb74d', textAlign: 'center' },
   modalCoords: { color: '#64ffda', fontSize: 16, fontWeight: '600' },
   modalButton: { marginTop: 8, backgroundColor: '#1e88e5', paddingHorizontal: 28, paddingVertical: 12, borderRadius: 30 },
-  modalButtonText: { color: '#fff', fontWeight: '700' }
+  modalButtonText: { color: '#fff', fontWeight: '700' },
+  // Run HUD
+  runHUD: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    backgroundColor: 'rgba(6,18,31,0.85)',
+    borderRadius: 14,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    zIndex: 10,
+  },
+  hudRow: { flexDirection: 'row', alignItems: 'baseline', marginBottom: 4 },
+  hudLabel: { color: '#64ffda', fontSize: 10, fontWeight: '700', width: 46 },
+  hudValue: { color: '#64ffda', fontSize: 18, fontWeight: '800', marginHorizontal: 4 },
+  hudUnit: { color: '#64ffda', fontSize: 11 },
+  // Post-run summary
+  summaryBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.65)', justifyContent: 'center', alignItems: 'center' },
+  summaryCard: { width: '80%', backgroundColor: '#0f2238', borderRadius: 20, padding: 24, alignItems: 'stretch', gap: 10 },
+  summaryTitle: { fontSize: 22, fontWeight: '800', color: '#fff', textAlign: 'center', marginBottom: 8 },
+  summaryRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 4, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: '#1e3a5f' },
+  summaryLabel: { color: '#9fb4cc', fontSize: 14 },
+  summaryValue: { color: '#64ffda', fontSize: 14, fontWeight: '700' },
+  summaryDoneBtn: { marginTop: 12, backgroundColor: '#1e88e5', paddingVertical: 12, borderRadius: 30, alignItems: 'center' },
+  summaryDoneBtnText: { color: '#fff', fontWeight: '700', fontSize: 16 },
 });
 
 export default MapScreen;

--- a/frontend/app/(tabs)/runs.tsx
+++ b/frontend/app/(tabs)/runs.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import api from '../services/api';
+
+interface Run {
+  id: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_seconds: number;
+  distance_meters: number;
+  vertical_meters: number;
+  max_speed_kmh: number;
+  avg_speed_kmh: number;
+  top_altitude_m: number | null;
+  bottom_altitude_m: number | null;
+}
+
+const formatDuration = (s: number): string => {
+  const mins = Math.floor(s / 60);
+  const secs = s % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+};
+
+interface StatCellProps {
+  label: string;
+  value: string;
+}
+
+const StatCell = ({ label, value }: StatCellProps) => (
+  <View style={styles.statCell}>
+    <Text style={styles.statValue}>{value}</Text>
+    <Text style={styles.statLabel}>{label}</Text>
+  </View>
+);
+
+const RunsScreen = () => {
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .get('/api/runs')
+      .then((r) => {
+        setRuns(r.data.runs ?? []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load runs');
+        setLoading(false);
+      });
+  }, []);
+
+  const renderRun = ({ item, index }: { item: Run; index: number }) => (
+    <View style={styles.runCard}>
+      <View style={styles.runHeader}>
+        <Text style={styles.runIndex}>Run #{runs.length - index}</Text>
+        <Text style={styles.runDate}>
+          {new Date(item.started_at).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          })}
+        </Text>
+      </View>
+      <View style={styles.statsGrid}>
+        <StatCell
+          label="Duration"
+          value={formatDuration(item.duration_seconds ?? 0)}
+        />
+        <StatCell
+          label="Vertical"
+          value={`${item.vertical_meters?.toFixed(0) ?? '—'} m`}
+        />
+        <StatCell
+          label="Distance"
+          value={`${((item.distance_meters ?? 0) / 1000).toFixed(2)} km`}
+        />
+        <StatCell
+          label="Top Speed"
+          value={`${item.max_speed_kmh?.toFixed(0) ?? '—'} km/h`}
+        />
+      </View>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Run History</Text>
+      {loading ? (
+        <ActivityIndicator color="#64ffda" style={styles.loader} />
+      ) : error ? (
+        <Text style={styles.error}>{error}</Text>
+      ) : runs.length === 0 ? (
+        <Text style={styles.empty}>No runs yet — go ski! 🎿</Text>
+      ) : (
+        <FlatList
+          data={runs}
+          keyExtractor={(r) => r.id}
+          renderItem={renderRun}
+          contentContainerStyle={styles.list}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#06121f' },
+  header: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: '#fff',
+    margin: 16,
+    marginBottom: 8,
+  },
+  loader: { marginTop: 40 },
+  error: { color: '#ff8a80', textAlign: 'center', marginTop: 40 },
+  empty: { color: '#9fb4cc', textAlign: 'center', marginTop: 60, fontSize: 16 },
+  list: { paddingHorizontal: 12, paddingBottom: 24 },
+  runCard: {
+    backgroundColor: '#0f2238',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 12,
+  },
+  runHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  runIndex: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  runDate: { color: '#9fb4cc', fontSize: 13 },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  statCell: {
+    width: '45%',
+  },
+  statValue: { color: '#64ffda', fontSize: 18, fontWeight: '700' },
+  statLabel: { color: '#9fb4cc', fontSize: 12, marginTop: 2 },
+});
+
+export default RunsScreen;

--- a/frontend/app/services/backgroundLocation.ts
+++ b/frontend/app/services/backgroundLocation.ts
@@ -15,13 +15,15 @@ TaskManager.defineTask(FLOW_LOCATION_TASK, async ({ data, error }) => {
   if (!locations || locations.length === 0) return;
 
   const latest = locations[locations.length - 1];
-  const { latitude, longitude } = latest.coords;
+  const { latitude, longitude, altitude, speed } = latest.coords;
 
   if (wsClient.isConnected()) {
     wsClient.send({
       type: 'location',
       lat: latitude,
       lng: longitude,
+      altitude_m: altitude ?? null,
+      speed_ms: speed ?? null,
       ts: Date.now(),
     });
   }

--- a/frontend/app/services/location.ts
+++ b/frontend/app/services/location.ts
@@ -5,6 +5,8 @@ import wsClient from './ws';
 export interface Coordinates {
   latitude: number;
   longitude: number;
+  altitude: number | null;   // metres ASL, null if unavailable
+  speed: number | null;     // m/s from GPS, null if unavailable
 }
 
 let locationSubscription: Location.LocationSubscription | null = null;
@@ -33,7 +35,9 @@ export const startLocationTracking = async (onUpdate?: (coords: Coordinates) => 
     (location) => {
       const coords: Coordinates = {
         latitude: location.coords.latitude,
-        longitude: location.coords.longitude
+        longitude: location.coords.longitude,
+        altitude: location.coords.altitude ?? null,
+        speed: location.coords.speed ?? null,
       };
 
       onUpdate?.(coords);
@@ -43,7 +47,9 @@ export const startLocationTracking = async (onUpdate?: (coords: Coordinates) => 
           type: 'location',
           lat: coords.latitude,
           lng: coords.longitude,
-          ts: Date.now()
+          altitude_m: coords.altitude,
+          speed_ms: coords.speed,
+          ts: Date.now(),
         });
       }
     }

--- a/frontend/app/services/runEngine.ts
+++ b/frontend/app/services/runEngine.ts
@@ -1,0 +1,222 @@
+import api from './api';
+import { Coordinates } from './location';
+
+export type RunState = 'IDLE' | 'ACTIVE' | 'ENDED';
+
+export interface RunSnapshot {
+  runId: string | null;
+  state: RunState;
+  startedAt: Date | null;
+  durationSeconds: number;
+  verticalMeters: number;
+  distanceMeters: number;
+  maxSpeedKmh: number;
+  avgSpeedKmh: number;
+  topAltitudeM: number | null;
+}
+
+// Haversine formula — returns distance in metres between two coordinates
+function haversineMeters(a: Coordinates, b: Coordinates): number {
+  const R = 6371000;
+  const lat1 = (a.latitude * Math.PI) / 180;
+  const lat2 = (b.latitude * Math.PI) / 180;
+  const dLat = ((b.latitude - a.latitude) * Math.PI) / 180;
+  const dLng = ((b.longitude - a.longitude) * Math.PI) / 180;
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
+interface RunStats {
+  vertical: number;
+  distance: number;
+  maxSpeed: number;
+  speedSum: number;
+  ticks: number;
+}
+
+class RunEngine {
+  private state: RunState = 'IDLE';
+  private triggerBuffer: Coordinates[] = []; // last 3 ticks (speed + altitude check)
+  private stopBuffer: number = 0;            // cumulative seconds below speed threshold
+  private runId: string | null = null;
+  private startedAt: Date | null = null;
+  private startAltitude: number | null = null;
+  private prevCoords: Coordinates | null = null;
+  private stats: RunStats = { vertical: 0, distance: 0, maxSpeed: 0, speedSum: 0, ticks: 0 };
+
+  private listeners: ((snap: RunSnapshot) => void)[] = [];
+
+  /** Register a listener that will be called on every state/stats change */
+  onUpdate(cb: (snap: RunSnapshot) => void): void {
+    this.listeners.push(cb);
+  }
+
+  /** Feed a new GPS coordinate into the state machine */
+  async feed(coords: Coordinates, groupId: string | null): Promise<void> {
+    const speedKmh = (coords.speed ?? 0) * 3.6;
+
+    if (this.state === 'IDLE') {
+      this.triggerBuffer.push(coords);
+      if (this.triggerBuffer.length > 3) this.triggerBuffer.shift();
+      if (this.shouldStart(speedKmh)) {
+        await this.startRun(coords, groupId);
+      }
+    } else if (this.state === 'ACTIVE') {
+      this.updateStats(coords, speedKmh);
+      if (this.shouldEnd(speedKmh)) {
+        await this.endRun(coords);
+      } else {
+        this.emit();
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // State transition helpers
+  // ---------------------------------------------------------------------------
+
+  private shouldStart(speedKmh: number): boolean {
+    if (this.triggerBuffer.length < 3) return false;
+
+    const fastEnough = this.triggerBuffer.every((c) => (c.speed ?? 0) * 3.6 >= 15);
+    if (!fastEnough) return false;
+
+    // Altitude dropping: first tick altitude is higher than last tick altitude
+    const first = this.triggerBuffer[0];
+    const last = this.triggerBuffer[2];
+    const altAvailable =
+      first.altitude !== null && last.altitude !== null;
+    const dropping =
+      altAvailable && first.altitude! - last.altitude! >= 2;
+
+    // Fallback when GPS altitude is permanently null: require faster speed threshold
+    return dropping || (!altAvailable && speedKmh >= 20);
+  }
+
+  private shouldEnd(speedKmh: number): boolean {
+    const TICK_INTERVAL_S = 5; // approximate GPS tick interval
+    if (speedKmh < 5) {
+      this.stopBuffer += TICK_INTERVAL_S;
+      return this.stopBuffer >= 10;
+    }
+    this.stopBuffer = 0;
+    return false;
+  }
+
+  private async startRun(coords: Coordinates, groupId: string | null): Promise<void> {
+    this.state = 'ACTIVE';
+    this.startedAt = new Date();
+    this.startAltitude = coords.altitude;
+    this.stats = { vertical: 0, distance: 0, maxSpeed: 0, speedSum: 0, ticks: 0 };
+    this.prevCoords = coords;
+    this.stopBuffer = 0;
+
+    try {
+      const res = await api.post('/api/runs/start', {
+        group_id: groupId,
+        top_altitude_m: coords.altitude,
+        started_at: this.startedAt.toISOString(),
+      });
+      this.runId = res.data.run_id;
+    } catch (err) {
+      console.warn('[RunEngine] Failed to start run on server:', err);
+      // Keep running locally even if network fails; runId stays null
+    }
+
+    this.emit();
+  }
+
+  private async endRun(coords: Coordinates): Promise<void> {
+    this.state = 'ENDED';
+    const ended = new Date();
+    const duration = Math.round(
+      (ended.getTime() - (this.startedAt?.getTime() ?? ended.getTime())) / 1000
+    );
+    const avgSpeedKmh =
+      this.stats.ticks > 0
+        ? Math.round((this.stats.speedSum / this.stats.ticks) * 10) / 10
+        : 0;
+
+    if (this.runId) {
+      const shouldDiscard = duration < 30 || this.stats.distance < 50;
+      try {
+        if (shouldDiscard) {
+          await api.post(`/api/runs/${this.runId}/discard`);
+        } else {
+          await api.post(`/api/runs/${this.runId}/end`, {
+            ended_at: ended.toISOString(),
+            duration_seconds: duration,
+            distance_meters: Math.round(this.stats.distance),
+            vertical_meters: Math.round(this.stats.vertical),
+            max_speed_kmh: Math.round(this.stats.maxSpeed * 10) / 10,
+            avg_speed_kmh: avgSpeedKmh,
+            bottom_altitude_m: coords.altitude,
+          });
+        }
+      } catch (err) {
+        console.warn('[RunEngine] Failed to end/discard run on server:', err);
+      }
+    }
+
+    this.emit();
+
+    // Auto-reset to IDLE after 2 s (gives UI time to show the summary card)
+    setTimeout(() => {
+      this.state = 'IDLE';
+      this.runId = null;
+      this.startedAt = null;
+      this.startAltitude = null;
+      this.prevCoords = null;
+      this.triggerBuffer = [];
+      this.stopBuffer = 0;
+      this.stats = { vertical: 0, distance: 0, maxSpeed: 0, speedSum: 0, ticks: 0 };
+      this.emit();
+    }, 2000);
+  }
+
+  private updateStats(coords: Coordinates, speedKmh: number): void {
+    // Vertical drop from start altitude
+    if (coords.altitude !== null && this.startAltitude !== null) {
+      const drop = this.startAltitude - coords.altitude;
+      this.stats.vertical = Math.max(0, drop);
+    }
+
+    // Cumulative distance
+    if (this.prevCoords) {
+      this.stats.distance += haversineMeters(this.prevCoords, coords);
+    }
+
+    // Speed stats
+    this.stats.maxSpeed = Math.max(this.stats.maxSpeed, speedKmh);
+    this.stats.speedSum += speedKmh;
+    this.stats.ticks++;
+
+    this.prevCoords = coords;
+  }
+
+  private emit(): void {
+    const avgSpeedKmh =
+      this.stats.ticks > 0 ? this.stats.speedSum / this.stats.ticks : 0;
+
+    const snap: RunSnapshot = {
+      runId: this.runId,
+      state: this.state,
+      startedAt: this.startedAt,
+      durationSeconds: this.startedAt
+        ? Math.round((Date.now() - this.startedAt.getTime()) / 1000)
+        : 0,
+      verticalMeters: this.stats.vertical,
+      distanceMeters: this.stats.distance,
+      maxSpeedKmh: this.stats.maxSpeed,
+      avgSpeedKmh,
+      topAltitudeM: this.startAltitude,
+    };
+
+    this.listeners.forEach((cb) => cb(snap));
+  }
+}
+
+export const runEngine = new RunEngine();
+export default runEngine;


### PR DESCRIPTION
Closes #37

## Changes
- DB migration 004_runs.sql (runs table + altitude/speed on locations)
- Backend /api/runs routes (start/end/discard/list/detail)
- Run auto-detection state machine (speed + altitude thresholds)
- Live HUD overlay on map tab during active run
- Post-run summary modal
- Runs history tab (replaces ipod tab)

## Test
- tsc --noEmit passes
- All acceptance criteria in sage-brief-37.md verified