### PR TITLE
feat: stats dashboard (#38)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,7 @@ const locationRoutes = require('./routes/locations');
 const sosRoutes = require('./routes/sos');
 const adminRoutes = require('./routes/admin');
 const runRoutes = require('./routes/runs');
+const statsRoutes = require('./routes/stats');
 
 const app = express();
 const server = http.createServer(app);
@@ -30,6 +31,7 @@ app.use('/api/locations', locationRoutes);
 app.use('/api/sos', sosRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/runs', runRoutes);
+app.use('/api/stats', statsRoutes);
 
 // WebSocket for real-time: GPS pings + intercom signaling
 setupWebSocket(server);

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -1,0 +1,112 @@
+// app/backend/src/routes/stats.js
+const express = require('express');
+const router = express.Router();
+const pool = require('../config/db');
+const { requireAuth } = require('../middleware/auth');
+
+// GET /api/stats/me — Full season stats for the authenticated user
+router.get('/me', requireAuth, async (req, res) => {
+  try {
+    const userId = req.user.userId;
+
+    // 1. Aggregated season totals + personal bests in a single query
+    const totalsResult = await pool.query(
+      `SELECT
+         COUNT(*)::int                                   AS total_runs,
+         COALESCE(SUM(vertical_meters), 0)::float       AS total_vertical_m,
+         COALESCE(SUM(duration_seconds), 0)::int        AS total_duration_s,
+         COALESCE(SUM(distance_meters), 0)::float       AS total_distance_m,
+         COUNT(DISTINCT DATE(started_at))::int          AS days_on_mountain,
+         COALESCE(MAX(max_speed_kmh), 0)::float         AS pb_top_speed_kmh,
+         COALESCE(MAX(duration_seconds), 0)::int        AS pb_longest_run_s,
+         COALESCE(MAX(distance_meters), 0)::float       AS pb_longest_distance_m,
+         -- Speed consistency: stddev of avg_speed_kmh (lower = more consistent)
+         COALESCE(STDDEV(avg_speed_kmh), 0)::float      AS speed_stddev
+       FROM runs
+       WHERE user_id = $1 AND status = 'completed'`,
+      [userId]
+    );
+
+    // 2. Most vertical in a single day
+    const bestDayVertResult = await pool.query(
+      `SELECT COALESCE(MAX(day_vert), 0)::float AS pb_best_day_vert_m
+       FROM (
+         SELECT DATE(started_at) AS day, SUM(vertical_meters) AS day_vert
+         FROM runs
+         WHERE user_id = $1 AND status = 'completed'
+         GROUP BY DATE(started_at)
+       ) sub`,
+      [userId]
+    );
+
+    // 3. Per-day vertical for season chart (last 90 days max)
+    const chartResult = await pool.query(
+      `SELECT
+         DATE(started_at)               AS day,
+         SUM(vertical_meters)::float    AS vert_m,
+         COUNT(*)::int                  AS run_count
+       FROM runs
+       WHERE user_id = $1 AND status = 'completed'
+         AND started_at >= NOW() - INTERVAL '90 days'
+       GROUP BY DATE(started_at)
+       ORDER BY day ASC`,
+      [userId]
+    );
+
+    const totals = totalsResult.rows[0];
+    const bestDayVert = bestDayVertResult.rows[0].pb_best_day_vert_m;
+
+    // 4. Skill Score (0–100)
+    //
+    // Formula (three equally-weighted components, each 0–33.3):
+    //
+    //   A. Speed component (top speed relative to 120 km/h ceiling):
+    //      speed_score = MIN(pb_top_speed_kmh / 120, 1) * 33.3
+    //
+    //   B. Consistency component (lower stddev of avg_speed = higher score):
+    //      consistency_score = MAX(0, 1 - speed_stddev / 30) * 33.3
+    //      (stddev ≥ 30 → 0; stddev = 0 → 33.3)
+    //
+    //   C. Volume component (vert-days — saturates at 50,000 m):
+    //      volume_score = MIN(total_vertical_m / 50000, 1) * 33.4
+    //
+    //   skill_score = ROUND(speed_score + consistency_score + volume_score)
+    //
+    // First-run users get 0 (no data → all components zero).
+
+    let skillScore = 0;
+    if (totals.total_runs > 0) {
+      const speedScore = Math.min(totals.pb_top_speed_kmh / 120, 1) * 33.3;
+      const consistencyScore = Math.max(0, 1 - totals.speed_stddev / 30) * 33.3;
+      const volumeScore = Math.min(totals.total_vertical_m / 50000, 1) * 33.4;
+      skillScore = Math.round(speedScore + consistencyScore + volumeScore);
+    }
+
+    res.json({
+      season: {
+        total_runs: totals.total_runs,
+        total_vertical_m: totals.total_vertical_m,
+        total_duration_s: totals.total_duration_s,
+        total_distance_m: totals.total_distance_m,
+        days_on_mountain: totals.days_on_mountain,
+      },
+      personal_bests: {
+        top_speed_kmh: totals.pb_top_speed_kmh,
+        best_day_vert_m: bestDayVert,
+        longest_run_s: totals.pb_longest_run_s,
+        longest_distance_m: totals.pb_longest_distance_m,
+      },
+      skill_score: skillScore,
+      chart: chartResult.rows.map(r => ({
+        day: r.day,           // "2025-02-14"
+        vert_m: r.vert_m,
+        run_count: r.run_count,
+      })),
+    });
+  } catch (err) {
+    console.error('[Stats] GET /me error:', err);
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+});
+
+module.exports = router;

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -73,6 +73,13 @@ const TabsLayout = () => {
         }}
       />
       <Tabs.Screen
+        name="stats"
+        options={{
+          title: 'Stats',
+          tabBarIcon: ({ color, size }) => <Ionicons name="bar-chart-outline" color={color} size={size} />
+        }}
+      />
+      <Tabs.Screen
         name="settings"
         options={{
           title: 'Settings',

--- a/frontend/app/(tabs)/stats.tsx
+++ b/frontend/app/(tabs)/stats.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import api from '../services/api';
+
+// --- Interfaces ---
+
+interface SeasonStats {
+  total_runs: number;
+  total_vertical_m: number;
+  total_duration_s: number;
+  total_distance_m: number;
+  days_on_mountain: number;
+}
+
+interface PersonalBests {
+  top_speed_kmh: number;
+  best_day_vert_m: number;
+  longest_run_s: number;
+  longest_distance_m: number;
+}
+
+interface ChartDay {
+  day: string;       // "YYYY-MM-DD"
+  vert_m: number;
+  run_count: number;
+}
+
+interface StatsPayload {
+  season: SeasonStats;
+  personal_bests: PersonalBests;
+  skill_score: number;         // 0–100
+  chart: ChartDay[];
+}
+
+// --- Pure-RN bar chart ---
+
+const VertChart = ({ data }: { data: ChartDay[] }) => {
+  if (!data.length) return null;
+  const maxVert = Math.max(...data.map(d => d.vert_m), 1);
+  const BAR_MAX_HEIGHT = 80;
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <View style={{ flexDirection: 'row', alignItems: 'flex-end', paddingVertical: 8, gap: 4 }}>
+        {data.map(d => {
+          const barH = Math.max((d.vert_m / maxVert) * BAR_MAX_HEIGHT, 4);
+          const label = d.day.slice(5); // "MM-DD"
+          return (
+            <View key={d.day} style={{ alignItems: 'center', width: 28 }}>
+              <View style={{ width: 20, height: barH, backgroundColor: '#1e88e5', borderRadius: 4 }} />
+              <Text style={{ color: '#9fb4cc', fontSize: 9, marginTop: 3 }}>{label}</Text>
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+};
+
+// --- Helpers ---
+
+const formatDuration = (s: number): string => {
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+};
+
+const skillTier = (score: number): string => {
+  if (score < 20) return 'Beginner';
+  if (score < 40) return 'Intermediate';
+  if (score < 60) return 'Advanced';
+  if (score < 80) return 'Expert';
+  return 'Elite';
+};
+
+// --- Sub-components ---
+
+const StatCard = ({ label, value }: { label: string; value: string }) => (
+  <View style={styles.statCard}>
+    <Text style={styles.statValue}>{value}</Text>
+    <Text style={styles.statLabel}>{label}</Text>
+  </View>
+);
+
+const SectionHeader = ({ title }: { title: string }) => (
+  <Text style={styles.sectionHeader}>{title}</Text>
+);
+
+// --- Main screen ---
+
+const StatsScreen = () => {
+  const [data, setData] = useState<StatsPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .get<StatsPayload>('/api/stats/me')
+      .then(r => { setData(r.data); setLoading(false); })
+      .catch(() => { setError('Failed to load stats'); setLoading(false); });
+  }, []);
+
+  if (loading) return <ActivityIndicator color="#64ffda" style={styles.loader} />;
+  if (error) return <Text style={styles.error}>{error}</Text>;
+  if (!data) return null;
+
+  const isEmpty = data.season.total_runs === 0;
+
+  if (isEmpty) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <Text style={styles.emptyIcon}>🎿</Text>
+        <Text style={styles.emptyTitle}>No runs yet this season</Text>
+        <Text style={styles.emptySubtitle}>
+          Head out on the mountain — your stats will appear here after your first run.
+        </Text>
+      </View>
+    );
+  }
+
+  const { season, personal_bests: pb, skill_score, chart } = data;
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.header}>Stats</Text>
+
+      {/* Personal Bests */}
+      <SectionHeader title="⭐  Personal Bests" />
+      <View style={styles.grid}>
+        <StatCard label="Top Speed" value={`${pb.top_speed_kmh.toFixed(0)} km/h`} />
+        <StatCard label="Best Day Vert" value={`${pb.best_day_vert_m.toFixed(0)} m`} />
+        <StatCard label="Longest Run" value={formatDuration(pb.longest_run_s)} />
+        <StatCard label="Longest Distance" value={`${(pb.longest_distance_m / 1000).toFixed(2)} km`} />
+      </View>
+
+      {/* Season Totals */}
+      <SectionHeader title="📅  This Season" />
+      <View style={styles.grid}>
+        <StatCard label="Total Runs" value={String(season.total_runs)} />
+        <StatCard label="Total Vertical" value={`${season.total_vertical_m.toFixed(0)} m`} />
+        <StatCard label="Days on Mountain" value={String(season.days_on_mountain)} />
+        <StatCard label="Total Time" value={formatDuration(season.total_duration_s)} />
+      </View>
+
+      {/* Chart */}
+      <SectionHeader title="📊  Vertical Per Day" />
+      <View style={styles.chartContainer}>
+        <VertChart data={chart} />
+      </View>
+
+      {/* Skill Score */}
+      <SectionHeader title="🎯  Skill Score" />
+      <View style={styles.skillContainer}>
+        <View style={styles.skillCircle}>
+          <Text style={styles.skillNumber}>{skill_score}</Text>
+          <Text style={styles.skillOutOf}>/100</Text>
+        </View>
+        <Text style={styles.skillTier}>{skillTier(skill_score)}</Text>
+        <Text style={styles.skillHint}>
+          Based on top speed, consistency, and total vertical
+        </Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#06121f' },
+  content: { paddingBottom: 40 },
+  center: { justifyContent: 'center', alignItems: 'center', padding: 32 },
+  loader: { flex: 1, marginTop: 60 },
+  error: { color: '#ff8a80', textAlign: 'center', marginTop: 60, fontSize: 16 },
+  header: { fontSize: 22, fontWeight: '800', color: '#fff', margin: 16, marginBottom: 4 },
+  sectionHeader: { color: '#64ffda', fontSize: 14, fontWeight: '700', marginHorizontal: 16, marginTop: 20, marginBottom: 8, textTransform: 'uppercase', letterSpacing: 1 },
+  grid: { flexDirection: 'row', flexWrap: 'wrap', paddingHorizontal: 12, gap: 10 },
+  statCard: { width: '45%', backgroundColor: '#0f2238', borderRadius: 14, padding: 14, marginHorizontal: 4 },
+  statValue: { color: '#64ffda', fontSize: 20, fontWeight: '800' },
+  statLabel: { color: '#9fb4cc', fontSize: 12, marginTop: 4 },
+  chartContainer: { marginHorizontal: 16, backgroundColor: '#0f2238', borderRadius: 14, padding: 12 },
+  skillContainer: { alignItems: 'center', backgroundColor: '#0f2238', borderRadius: 14, marginHorizontal: 16, paddingVertical: 24 },
+  skillCircle: { flexDirection: 'row', alignItems: 'flex-end' },
+  skillNumber: { color: '#64ffda', fontSize: 56, fontWeight: '900', lineHeight: 64 },
+  skillOutOf: { color: '#9fb4cc', fontSize: 18, marginBottom: 8, marginLeft: 2 },
+  skillTier: { color: '#fff', fontSize: 18, fontWeight: '700', marginTop: 4 },
+  skillHint: { color: '#9fb4cc', fontSize: 12, marginTop: 6, textAlign: 'center', paddingHorizontal: 24 },
+  emptyIcon: { fontSize: 48, marginBottom: 16 },
+  emptyTitle: { color: '#fff', fontSize: 20, fontWeight: '700', marginBottom: 8 },
+  emptySubtitle: { color: '#9fb4cc', fontSize: 14, textAlign: 'center', lineHeight: 22 },
+});
+
+export default StatsScreen;


### PR DESCRIPTION
Closes #38

## Changes
- Backend GET /api/stats/me (season totals, personal bests, per-day chart, skill score)
- New stats.tsx tab (Personal Bests, This Season, Vertical Per Day chart, Skill Score)
- Tab layout updated to include Stats tab
- Pure RN chart — no new dependencies
- Empty state for first-time users

## Test
- tsc --noEmit passes
- All acceptance criteria in sage-brief-38.md verified