### PR TITLE
Add .cursorrules for Cursor IDE integration

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,96 @@
+# Wooverse — Cursor Rules
+# Ski app: group intercom, live GPS map, SOS alerts. Expo RN + Node.js + Next.js + PostgreSQL.
+
+## Stack
+
+- **Frontend:** Expo (React Native) — iOS + Android
+- **Backend:** Node.js + Express, port 8100
+- **WebSocket:** ws:// on same Express server, route /ws
+- **Admin:** Next.js, port 8101
+- **Database:** PostgreSQL — isolated `wooverse` DB
+- **Auth:** Device-based (no passwords), JWT tokens
+- **Push Notifications:** Expo Push API
+- **BLE:** Wooverse smart goggles audio bridge (native build only, not Expo Go)
+- **Maps:** Gaode Maps (AMap) via `GAODE_API_KEY`
+
+## Project Structure
+
+```
+/opt/wooverse/
+├── backend/          Node.js + Express + WebSocket
+│   ├── src/          source code
+│   ├── tests/        test suite
+│   ├── scripts/      utility scripts
+│   └── migrations/   SQL migration files (001_initial.sql, 002_phase3.sql, 003_push_tokens.sql)
+├── frontend/         Expo React Native app
+│   ├── src/
+│   │   ├── screens/     Registration, Map, Intercom, SOS, iPod, Settings
+│   │   ├── components/  shared UI components
+│   │   ├── services/    API client, WebSocket, BLE
+│   │   └── hooks/       custom hooks
+│   └── app.json
+├── admin/            Next.js admin dashboard
+│   └── src/
+└── docs/             Testing manuals, Argus review notes
+```
+
+## Conventions
+
+### API Patterns
+- Routes: `/api/<resource>` — RESTful, JSON request/response
+- Auth: JWT in `Authorization: Bearer <token>` header
+- Admin routes: require `X-Admin-Password` header
+- Error responses: `{ "error": "message" }` with appropriate HTTP status
+- All new endpoints must include request validation
+
+### Database
+- UUID primary keys for users
+- Timestamps: `created_at`, `updated_at`, `joined_at`, `triggered_at`, `resolved_at`
+- Upsert pattern for locations table (single row per user)
+- Row-level security not used — app-level auth
+- Migration files numbered sequentially; never edit existing migrations, always add new ones
+
+### Frontend
+- Expo Router for navigation
+- Screens: Registration, Map, Intercom, SOS, iPod, Settings
+- Platform-specific code: use `Platform.OS` checks, not separate files
+- Always wrap native-only features (BLE) in Platform.OS guards
+- Expo Go compatible unless BLE required
+
+### General
+- Environment variables: never hardcode. Use `.env` (backend), `.env.local` (admin), `.env` with `EXPO_PUBLIC_` prefix (frontend)
+- Credentials: never in source code. Reference env vars only.
+- Test files: `*.test.ts` or `*.test.js` in `tests/` directories
+- E2E tests: run before every push via pre-push hook (68/68 currently passing)
+
+## Anti-Patterns — NEVER
+
+### Business Logic
+- ❌ Never let Cursor generate complex business logic without explicit spec and human review
+- ❌ Never trust Cursor-generated auth/security code without pipeline validation (vault-woo + argus-woo)
+- ❌ Never let Cursor modify database schema without migration file review
+- ❌ Never let Cursor change WebSocket protocol without testing against existing clients
+
+### Code Quality
+- ❌ Never commit console.log in production code (use proper logging)
+- ❌ Never hardcode URLs or IPs (use env vars)
+- ❌ Never bypass TypeScript strict mode without explicit justification
+- ❌ Never merge PR without pipeline passing (argus-woo approval gate)
+- ❌ Never push directly to main (features branches → PR → merge)
+
+### Safety
+- ❌ Never expose credentials in code, comments, or commit messages
+- ❌ Never disable SSL/TLS or auth checks in production code
+- ❌ Never bypass rate limiting or validation middleware
+- ❌ Never commit `.env` files or credential-bearing configs
+
+## Cursor Workflow
+
+- **Cmd+I (Composer):** Use for features >50 lines. Write a short spec comment first, let Cursor generate, then review every line.
+- **Cmd+K (Inline):** Use for targeted edits — "add input validation", "add error handling to this function"
+- **Cmd+L (Chat):** Use for understanding — "explain this WebSocket handler", "find the race condition in this file"
+- **Tab (Complete):** Accept for boilerplate (imports, type definitions, component props); review for logic
+
+## Pipeline Gate
+
+Every PR → argus-woo reviews (docs, security, compliance) → vault-woo checks (credentials, secrets) → auto-merge if approved. Cursor-generated code is NOT exempt from this pipeline. All code, whether hand-written or Cursor-generated, goes through the same validation gate.

--- a/.cursorrules
+++ b/.cursorrules
@@ -98,6 +98,15 @@
 - **Cmd+L (Chat):** Use for understanding — "explain this WebSocket handler", "find the race condition in this file"
 - **Tab (Complete):** Accept for boilerplate (imports, type definitions, component props); review for logic
 
+## Memory Rules — Prevent Duplicate Work
+
+Before generating ANY code, Cursor MUST:
+1. **Read `docs/SPEC_REGISTER.md`** — confirms the feature doesn't already exist
+2. **Read `docs/DECISIONS.md`** — respects past architecture choices (no reversing decisions)
+3. **After task completion** — update SPEC_REGISTER.md with what was built
+
+Every PR → argus-woo verifies SPEC_REGISTER.md was updated. If a feature was built and the register wasn't updated → auto-reject.
+
 ## Pipeline Gate
 
 ### Branch-Per-Task Rule
@@ -109,6 +118,10 @@ argus-woo runs `git diff main...HEAD --stat` on every PR. Auto-reject if:
 - Config files changed without justification
 - Existing code deleted without `.deleted.YYYYMMDD` rename
 - More than 5 files changed for a single-feature PR
+- `docs/SPEC_REGISTER.md` not updated for the new feature
+
+### Duplicate Detection Gate
+argus-woo checks: does this PR's feature already exist in SPEC_REGISTER.md? If yes → auto-reject with "duplicate of existing feature."
 
 ### Full Pipeline
-Every PR → architect-woo (design) → backlead-woo (backend) → frontlead-woo (frontend) → vault-woo (secrets) → argus-woo (docs/scope/diff gate) → auto-merge if approved. Cursor-generated code is NOT exempt. All code, whether hand-written or Cursor-generated, goes through the same gates.
+Every PR → architect-woo (design) → backlead-woo (backend) → frontlead-woo (frontend) → vault-woo (secrets) → argus-woo (docs/scope/diff/duplicate gate) → auto-merge if approved. Cursor-generated code is NOT exempt. All code, whether hand-written or Cursor-generated, goes through the same gates.

--- a/.cursorrules
+++ b/.cursorrules
@@ -65,18 +65,25 @@
 
 ## Anti-Patterns — NEVER
 
+### Scope Discipline (CRITICAL — prevents overwrites)
+- ❌ NEVER touch files outside the task scope. SOS task = only sos.js/SOSScreen.tsx/sos migration. If you touch Registration.tsx, package.json, or any unrelated file → PR auto-rejected.
+- ❌ NEVER refactor adjacent code. Fix the bug, add the feature — don't "clean up" nearby functions.
+- ❌ NEVER modify package.json, app.json, tsconfig, or any config file without explicit instruction.
+- ❌ NEVER delete existing code. Rename files with `.deleted.YYYYMMDD` suffix if removal is truly needed.
+- ❌ NEVER rewrite an entire file when only 3 lines need changing. Use targeted edits.
+
 ### Business Logic
-- ❌ Never let Cursor generate complex business logic without explicit spec and human review
-- ❌ Never trust Cursor-generated auth/security code without pipeline validation (vault-woo + argus-woo)
-- ❌ Never let Cursor modify database schema without migration file review
-- ❌ Never let Cursor change WebSocket protocol without testing against existing clients
+- ❌ Never generate complex business logic without explicit spec and human review
+- ❌ Never generate auth/security code without pipeline validation (vault-woo + argus-woo)
+- ❌ Never modify database schema without creating a new migration file (never edit existing migrations)
+- ❌ Never change WebSocket protocol without testing against existing clients
 
 ### Code Quality
 - ❌ Never commit console.log in production code (use proper logging)
 - ❌ Never hardcode URLs or IPs (use env vars)
 - ❌ Never bypass TypeScript strict mode without explicit justification
 - ❌ Never merge PR without pipeline passing (argus-woo approval gate)
-- ❌ Never push directly to main (features branches → PR → merge)
+- ❌ Never push directly to main (feature branches → PR → merge)
 
 ### Safety
 - ❌ Never expose credentials in code, comments, or commit messages
@@ -93,4 +100,15 @@
 
 ## Pipeline Gate
 
-Every PR → argus-woo reviews (docs, security, compliance) → vault-woo checks (credentials, secrets) → auto-merge if approved. Cursor-generated code is NOT exempt from this pipeline. All code, whether hand-written or Cursor-generated, goes through the same validation gate.
+### Branch-Per-Task Rule
+Every task gets its own branch from main. One task = one branch. Never stack features.
+
+### Diff Gate (auto-reject scope creep)
+argus-woo runs `git diff main...HEAD --stat` on every PR. Auto-reject if:
+- Files touched are outside the task's expected scope
+- Config files changed without justification
+- Existing code deleted without `.deleted.YYYYMMDD` rename
+- More than 5 files changed for a single-feature PR
+
+### Full Pipeline
+Every PR → architect-woo (design) → backlead-woo (backend) → frontlead-woo (frontend) → vault-woo (secrets) → argus-woo (docs/scope/diff gate) → auto-merge if approved. Cursor-generated code is NOT exempt. All code, whether hand-written or Cursor-generated, goes through the same gates.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,56 @@
+# Architecture Decisions — Wooverse
+
+> Record every non-obvious decision. Before any task that touches architecture, read this.
+> If you're about to reverse a decision here, stop and discuss first.
+
+## Decisions
+
+### D1: WebSocket over SSE
+**Date:** 2026-02 · **By:** Henry
+**Why:** Bidirectional communication needed for intercom audio relay. SSE is server→client only. WebSocket supports binary frames (audio) natively.
+**Do not change to SSE** without solving the audio uplink problem.
+
+### D2: Opus Audio Codec, not PCM
+**Date:** 2026-03 · **By:** Henry
+**Why:** 16kHz Opus mono is ~6x smaller than PCM at equivalent quality. Critical for BLE bandwidth (goggles bridge). Tested with 50 concurrent users on M1 simulation.
+**Do not change** without BLE throughput profiling with real hardware.
+
+### D3: Upsert for Locations, not Append
+**Date:** 2026-04 · **By:** Henry
+**Why:** 50 skiers × 1 GPS update/sec × 3600 sec = 180 million rows/hour if using append. Upsert keeps 50 rows (one per user). For real-time GPS, append is a scaling disaster.
+**Do not change to append** without profiling against 50+ user load test.
+
+### D4: App-Level Auth, not PostgreSQL RLS
+**Date:** 2026-02 · **By:** Henry
+**Why:** JWT validation in Express middleware is simpler and avoids per-query RLS overhead. Device-bound auth means we control token lifecycle, not DB roles.
+**Do not add RLS** without benchmarking against current middleware approach.
+
+### D5: UUID Primary Keys, not Serial
+**Date:** 2026-02 · **By:** Henry
+**Why:** Device-bound auth means user IDs are generated client-side. Predictable serial IDs leak user count and allow enumeration. UUIDs prevent this.
+**No change.**
+
+### D6: Expo Router, not React Navigation
+**Date:** 2026-05 · **By:** frontlead-woo
+**Why:** Expo Router is the official standard for new Expo projects. File-based routing. React Navigation remains available as underlying implementation.
+**Do not migrate back to React Navigation standalone.**
+
+### D7: Foreground GPS Only
+**Date:** 2026-05 · **By:** Peter
+**Why:** Privacy decision — skiers' locations stop sharing when app backgrounded. Battery conservation is a secondary benefit.
+**Do not add background GPS** without explicit approval and privacy review.
+
+### D8: Gaode Maps, not Google Maps
+**Date:** 2026-03 · **By:** Peter
+**Why:** Target market is China ski resorts. Gaode (AMap) has better coverage, Chinese UI support, and operates without VPN.
+**No change.**
+
+## Anti-Decisions (Rejected Approaches)
+
+| Approach | Rejected Why | Date |
+|----------|-------------|------|
+| GraphQL | Added latency for real-time GPS, complex BLE audio handling. REST + WebSocket simpler | 2026-02 |
+| MongoDB | Relational data (users, groups, SOS history). SQL fits better. JSONB in Postgres covers flexible fields | 2026-02 |
+| Firebase | Vendor lock-in. Self-hosted Postgres + Express gives full control | 2026-02 |
+| React Navigation standalone | Expo Router is standard path forward | 2026-05 |
+| Background GPS | Privacy + battery. Foreground-only is explicit decision | 2026-05 |

--- a/docs/SPEC_REGISTER.md
+++ b/docs/SPEC_REGISTER.md
@@ -1,0 +1,53 @@
+# Spec Register — What Exists in Wooverse
+
+> Single source of truth. Read before any task. Update after any task.
+> If a feature isn't listed here, it doesn't exist yet.
+
+## Phase 1 — Core Foundation
+- **Device Registration:** Registration.tsx → POST /api/register → users table
+- **JWT Auth:** Token-based, device-bound, no passwords
+- **Group Joining:** JoinScreen.tsx → POST /api/groups/join → users.groups
+- **Group Creation:** POST /api/groups/create → groups table
+- **User Profile:** user metadata stored in users table (JSONB)
+- Built: 2026-02
+
+## Phase 2 — Intercom & GPS
+- **Push-to-Talk Intercom:** IntercomScreen.tsx → WebSocket "intercom_audio" binary frames
+- **BLE Goggles Bridge:** AudioBridge.ts → native audio relay (not Expo Go compatible)
+- **Audio Codec:** Opus @ 16kHz mono
+- **Live GPS Map:** MapScreen.tsx → Gaode Maps via GAODE_API_KEY
+- **Location Sharing:** WebSocket "location_update" → broadcast to group
+- **Location Storage:** Upsert pattern — single row per user in locations table
+- **Privacy:** GPS stops when app backgrounded
+- Built: 2026-03
+
+## Phase 3 — SOS & Database
+- **Manual SOS:** SOSScreen.tsx → POST /api/sos/trigger → sos_alerts table
+- **SOS Alert Flow:** Trigger → store in DB → push notification to group → WebSocket broadcast
+- **SOS Resolution:** POST /api/sos/resolve → updates resolved_at
+- **DB Migration:** 002_phase3.sql — sos_alerts table
+- Built: 2026-04
+
+## Phase 4 — Groups, UI, Push, Background GPS
+- **Group Management:** admin push, member lists, leave/rejoin
+- **Push Notifications:** Expo Push API — SOS alerts, group invites
+- **Background GPS:** foreground-only, stops on background (privacy decision)
+- **Admin Dashboard:** Next.js admin panel @ port 8101
+- **DB Migration:** 003_push_tokens.sql — push_tokens table
+- Built: 2026-05
+
+## Phase 5 — Features (in progress)
+- **Run Tracking:** RunTrackingScreen.tsx (branched, not merged)
+- **Stats Dashboard:** StatsDashboard.tsx (branched, not merged)
+- **Goggle Simulator:** dev tool for testing BLE without hardware (branched)
+- **Rebrand & Auth:** feature/rebrand-and-auth branch (not merged)
+
+## Future / Not Yet Built
+- [ ] Auto-SOS (prolonged inactivity trigger)
+- [ ] Offline SOS queue
+- [ ] Group chat text messages
+- [ ] Ski patrol admin panel
+- [ ] Weather integration
+- [ ] Slope difficulty overlay
+- [ ] Friend system (add/follow/search)
+- [ ] Battery optimization for GPS polling


### PR DESCRIPTION
Closes #49

## What
Adds `.cursorrules` to the wooverse repo root encoding our full tech stack, conventions, anti-patterns, and Cursor IDE workflow rules.

## Why
Every Cursor Composer/Chat session now starts aligned with our architecture decisions. No more explaining the stack to Cursor on every session.

## What `.cursorrules` covers
- **Stack:** Expo (React Native) · Node.js/Express · Next.js · PostgreSQL · WebSocket · BLE · Gaode Maps
- **Project structure:** backend/frontend/admin layout, migration conventions, test locations
- **API patterns:** RESTful routes, JWT auth, admin password header, error response format
- **Database conventions:** UUID PKs, timestamp fields, upsert pattern, migration numbering
- **Frontend conventions:** Expo Router, screen list, Platform.OS guards, Expo Go compatibility
- **Anti-patterns:** No unchecked business logic, no credentials in code, no direct main pushes, no console.log in prod
- **Cursor workflow:** Composer (>50 lines) → human review → PR → pipeline validation → merge
- **Pipeline gate:** All code goes through argus-woo + vault-woo regardless of origin

## Impact
- No code behavior changes
- Complementary to existing 7-agent Wooverse pipeline
- Human devs get immediate alignment in Cursor sessions