### PR TITLE
fix: clarify Leave Group confirmation — user stays logged in (#53)

### DIFF
--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -152,7 +152,7 @@ const SettingsScreen = () => {
   const handleLeaveGroup = useCallback(() => {
     Alert.alert(
       'Leave Group',
-      'Are you sure you want to leave your current group?',
+      'You will leave this group but your account stays active. You can join or create a new group anytime.',
       [
         { text: 'Cancel', style: 'cancel' },
         {


### PR DESCRIPTION
## What\nOne-line copy change: the Leave Group confirmation now explicitly says the account stays active, preventing the UX that made users feel their account was deleted.\n\n## Root cause\nBackend only removes `group_members` row — user record is untouched. But the old confirmation text ("Are you sure you want to leave your current group?") didn't communicate that, so users reaching the group-setup screen after leaving felt their entire account was wiped.\n\n## Change\n`frontend/app/(tabs)/settings.tsx` — confirmation message changed from:\n"Are you sure you want to leave your current group?"\nto:\n"You will leave this group but your account stays active. You can join or create a new group anytime."\n\nCloses #53