### PR TITLE
fix: intercom WS connect — restore wsClient.connect() (#22)

### DIFF
--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -62,6 +62,14 @@ const IntercomScreen = () => {
   }, []);
 
   useEffect(() => {
+    if (!userId || !groupId) return;
+    wsClient.connect(userId, groupId, displayName);
+    return () => {
+      wsClient.disconnect();
+    };
+  }, [userId, groupId, displayName]);
+
+  useEffect(() => {
     if (!userId) return;
     setMembers((prev) => ({
       ...prev,


### PR DESCRIPTION
## Summary
Restores the `wsClient.connect()` useEffect that was removed during PR #64.

## Bug
The Intercom tab permanently shows "Connecting to intercom..." with the PTT button disabled because `wsClient.connect()` is never called.

## Root Cause
PR #64 (#27/#28/#29/#34) accidentally deleted the useEffect that calls `wsClient.connect(userId, groupId, displayName)` on mount and `wsClient.disconnect()` on unmount.

## Fix
Re-add the useEffect (8 lines) in `intercom.tsx` after identity loading and before member state initialization.

## Files Changed
- `frontend/app/(tabs)/intercom.tsx`: +8 lines

Closes #22