### PR TITLE
Part of #3 — PR A: WS contracts + live GPS

### DIFF
--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { requireAuth } = require('../middleware/auth');
 const { pool } = require('../config/db');
+const { getGroupMemberPresence } = require('../services/ws');
 
 function generateInviteCode() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -97,6 +98,28 @@ router.get('/mine', requireAuth, async (req, res) => {
     );
     res.json(result.rows);
   } catch (e) {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Get full member roster with live presence and last known location
+// GET /api/groups/:groupId/members
+router.get('/:groupId/members', requireAuth, async (req, res) => {
+  const { groupId } = req.params;
+
+  try {
+    const membership = await pool.query(
+      'SELECT 1 FROM group_members WHERE group_id = $1 AND user_id = $2',
+      [groupId, req.user.userId]
+    );
+    if (membership.rowCount === 0) {
+      return res.status(403).json({ error: 'Not a group member' });
+    }
+
+    const members = await getGroupMemberPresence(groupId);
+    res.json({ members });
+  } catch (e) {
+    console.error('[groups] members error:', e.message);
     res.status(500).json({ error: 'Server error' });
   }
 });

--- a/backend/src/services/ws.js
+++ b/backend/src/services/ws.js
@@ -5,6 +5,8 @@ const { pool } = require('../config/db');
 const rooms = new Map();
 // User → ws mapping
 const userSockets = new Map();
+// User → ISO timestamp of last observed WS presence
+const lastSeenByUser = new Map();
 // Per-user audio sequence numbers
 const speakerSeq = new Map();
 // Goggle simulator registries (ephemeral — in-memory only)
@@ -36,6 +38,74 @@ async function ensureUserAllowed(userId) {
     throw err;
   }
   return record;
+}
+
+async function ensureGroupMembership(userId, groupId) {
+  if (!groupId) {
+    const err = new Error('missing_group');
+    err.code = 'missing_group';
+    throw err;
+  }
+
+  const result = await pool.query(
+    'SELECT 1 FROM group_members WHERE user_id = $1 AND group_id = $2',
+    [userId, groupId]
+  );
+  if (result.rowCount === 0) {
+    const err = new Error('not_group_member');
+    err.code = 'not_group_member';
+    throw err;
+  }
+}
+
+function isOpenSocket(socket) {
+  return socket?.readyState === 1;
+}
+
+function getRoomSocket(groupId, userId) {
+  const room = rooms.get(groupId);
+  if (!room) return null;
+  for (const client of room) {
+    if (client.userId === userId && isOpenSocket(client)) {
+      return client;
+    }
+  }
+  return null;
+}
+
+function getUserPresence(userId, groupId) {
+  const socket = groupId ? getRoomSocket(groupId, userId) : userSockets.get(userId);
+  const online = isOpenSocket(socket);
+  return {
+    online,
+    last_seen_at: online ? socket.lastSeenAt : (lastSeenByUser.get(userId) || null),
+  };
+}
+
+async function getGroupMemberPresence(groupId) {
+  const result = await pool.query(
+    `SELECT gm.user_id, u.name, l.lat, l.lng, l.updated_at AS location_updated_at
+     FROM group_members gm
+     JOIN users u ON u.id = gm.user_id
+     LEFT JOIN locations l ON l.user_id = gm.user_id AND l.group_id = gm.group_id
+     WHERE gm.group_id = $1
+     ORDER BY u.name ASC`,
+    [groupId]
+  );
+
+  return result.rows.map((member) => {
+    const presence = getUserPresence(member.user_id, groupId);
+    return {
+      user_id: member.user_id,
+      userId: member.user_id,
+      name: member.name,
+      online: presence.online,
+      last_seen_at: presence.last_seen_at,
+      lat: member.lat,
+      lng: member.lng,
+      location_updated_at: member.location_updated_at,
+    };
+  });
 }
 
 function startHeartbeat(ws) {
@@ -104,6 +174,11 @@ function setupWebSocket(server) {
 }
 
 async function handleMessage(ws, msg) {
+  if (ws.userId) {
+    ws.lastSeenAt = new Date().toISOString();
+    lastSeenByUser.set(ws.userId, ws.lastSeenAt);
+  }
+
   switch (msg.type) {
     case 'admin_join': {
       if (!msg.adminPassword || msg.adminPassword !== process.env.ADMIN_PASSWORD) {
@@ -121,6 +196,7 @@ async function handleMessage(ws, msg) {
     case 'join': {
       try {
         const userRecord = await ensureUserAllowed(msg.userId);
+        await ensureGroupMembership(msg.userId, msg.groupId);
         if (!rooms.has(msg.groupId)) rooms.set(msg.groupId, new Set());
         const room = rooms.get(msg.groupId);
         if (room.size >= 20) {
@@ -132,21 +208,36 @@ async function handleMessage(ws, msg) {
         ws.userId = msg.userId;
         ws.groupId = msg.groupId;
         ws.name = msg.name || userRecord.name;
+        ws.lastSeenAt = new Date().toISOString();
+        lastSeenByUser.set(msg.userId, ws.lastSeenAt);
         userSockets.set(msg.userId, ws);
         room.add(ws);
         speakerSeq.set(msg.userId, 0);
 
+        ws.send(JSON.stringify({ type: 'joined', groupId: msg.groupId }));
+        ws.send(JSON.stringify({
+          type: 'members_snapshot',
+          groupId: msg.groupId,
+          members: await getGroupMemberPresence(msg.groupId),
+        }));
+
         broadcastToGroup(msg.groupId, {
           type: 'member_joined',
           userId: msg.userId,
+          user_id: msg.userId,
           name: ws.name,
+          online: true,
+          last_seen_at: ws.lastSeenAt,
         }, ws);
-
-        ws.send(JSON.stringify({ type: 'joined', groupId: msg.groupId }));
       } catch (err) {
         if (err.code === 'user_banned') {
           ws.send(JSON.stringify({ type: 'error', message: 'Account banned' }));
           ws.close(4001, 'banned');
+          return;
+        }
+        if (err.code === 'not_group_member') {
+          ws.send(JSON.stringify({ type: 'error', message: 'Not a group member' }));
+          ws.close(1008, 'not_group_member');
           return;
         }
         ws.send(JSON.stringify({ type: 'error', message: 'Unable to join room' }));
@@ -156,28 +247,92 @@ async function handleMessage(ws, msg) {
     }
 
     case 'location': {
-      broadcastToGroup(msg.groupId, {
+      if (!ws.userId || !ws.groupId) {
+        ws.send(JSON.stringify({ type: 'error', message: 'unauthorized' }));
+        return;
+      }
+      const lat = Number(msg.lat);
+      const lng = Number(msg.lng);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+        ws.send(JSON.stringify({ type: 'error', message: 'invalid location' }));
+        return;
+      }
+      const altitudeM = msg.altitude_m == null ? null : Number(msg.altitude_m);
+      const speedMs = msg.speed_ms == null ? null : Number(msg.speed_ms);
+      const locationTs = Date.now();
+      ws.lastSeenAt = new Date().toISOString();
+      lastSeenByUser.set(ws.userId, ws.lastSeenAt);
+
+      broadcastToGroup(ws.groupId, {
         type: 'location',
-        userId: msg.userId,
-        lat: msg.lat,
-        lng: msg.lng,
-        ts: Date.now(),
+        userId: ws.userId,
+        user_id: ws.userId,
+        lat,
+        lng,
+        altitude_m: Number.isFinite(altitudeM) ? altitudeM : null,
+        speed_ms: Number.isFinite(speedMs) ? speedMs : null,
+        sent_at: msg.sent_at || msg.ts || null,
+        ts: locationTs,
       }, ws);
 
       try {
         await pool.query(
-          `INSERT INTO locations (user_id, group_id, lat, lng, updated_at)
-           VALUES ($1, $2, $3, $4, now())
+          `INSERT INTO locations (user_id, group_id, lat, lng, altitude_m, speed_kmh, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, now())
            ON CONFLICT (user_id) DO UPDATE
            SET group_id = excluded.group_id,
                lat = excluded.lat,
                lng = excluded.lng,
+               altitude_m = excluded.altitude_m,
+               speed_kmh = excluded.speed_kmh,
                updated_at = now()`,
-          [msg.userId, msg.groupId, msg.lat, msg.lng]
+          [
+            ws.userId,
+            ws.groupId,
+            lat,
+            lng,
+            Number.isFinite(altitudeM) ? altitudeM : null,
+            Number.isFinite(speedMs) ? speedMs * 3.6 : null,
+          ]
         );
       } catch (err) {
         console.error('[WS] Location persistence failed:', err.message);
       }
+      break;
+    }
+
+    case 'webrtc_signal': {
+      if (!ws.userId || !ws.groupId) {
+        ws.send(JSON.stringify({ type: 'error', message: 'unauthorized' }));
+        return;
+      }
+      if (!msg.target_user_id) {
+        ws.send(JSON.stringify({ type: 'error', message: 'target_user_id required' }));
+        return;
+      }
+      const targetSocket = getRoomSocket(ws.groupId, msg.target_user_id);
+      if (!targetSocket) {
+        ws.send(JSON.stringify({
+          type: 'webrtc_signal_failed',
+          target_user_id: msg.target_user_id,
+          reason: 'target_offline',
+        }));
+        return;
+      }
+      targetSocket.send(JSON.stringify({
+        type: 'webrtc_signal',
+        from_user_id: ws.userId,
+        signal: msg.signal,
+      }));
+      break;
+    }
+
+    case 'client_ping': {
+      ws.send(JSON.stringify({
+        type: 'server_pong',
+        ts: msg.ts,
+        server_ts: Date.now(),
+      }));
       break;
     }
 
@@ -371,7 +526,11 @@ function handleDisconnect(ws) {
     }
   }
   if (ws.userId) {
-    userSockets.delete(ws.userId);
+    ws.lastSeenAt = new Date().toISOString();
+    lastSeenByUser.set(ws.userId, ws.lastSeenAt);
+    if (userSockets.get(ws.userId) === ws) {
+      userSockets.delete(ws.userId);
+    }
     speakerSeq.delete(ws.userId);
     // Release channel floor if this user held it
     if (ws.groupId && channelFloor.get(ws.groupId) === ws.userId) {
@@ -391,7 +550,10 @@ function handleDisconnect(ws) {
     broadcastToGroup(ws.groupId, {
       type: 'member_left',
       userId: ws.userId,
+      user_id: ws.userId,
       name: ws.name,
+      online: false,
+      last_seen_at: ws.lastSeenAt,
     });
   }
   // Clean up goggle/central registries
@@ -420,7 +582,7 @@ function broadcastToRoom(roomName, msg, exclude = null) {
   if (!room) return;
   const payload = JSON.stringify(msg);
   for (const client of room) {
-    if (client !== exclude && client.readyState === 1) {
+    if (client !== exclude && isOpenSocket(client)) {
       client.send(payload);
     }
   }
@@ -438,4 +600,10 @@ function disconnectUser(userId, reason = 'admin_disconnect') {
   userSockets.delete(userId);
 }
 
-module.exports = { setupWebSocket, broadcastToGroup, broadcastToRoom, disconnectUser };
+module.exports = {
+  setupWebSocket,
+  broadcastToGroup,
+  broadcastToRoom,
+  disconnectUser,
+  getGroupMemberPresence,
+};

--- a/docs/SPEC_REGISTER.md
+++ b/docs/SPEC_REGISTER.md
@@ -18,6 +18,7 @@
 - **Live GPS Map:** MapScreen.tsx → Gaode Maps via GAODE_API_KEY
 - **Location Sharing:** WebSocket "location_update" → broadcast to group
 - **Location Storage:** Upsert pattern — single row per user in locations table
+- **Phase 2 PR A — WS contracts + live GPS:** Issue #3 Core Features. backend/src/services/ws.js sends members_snapshot on join with online/last_seen_at, relays authenticated same-room webrtc_signal, supports client_ping/server_pong, and preserves existing PTT, audio_chunk, SOS, goggle, heartbeat, and broadcastToRoom behavior. backend/src/routes/groups.js adds GET /api/groups/:groupId/members REST fallback with requireAuth and online/location data. frontend/app/services/ws.ts adds typed onLocation, onPresence, onMemberSnapshot handlers plus sendWebRtcSignal and sendPing helpers. frontend/app/(tabs)/map.tsx consumes live WS locations for instant teammate pin updates while keeping REST polling fallback. frontend/app/services/location.ts includes altitude/speed in location sends with throttling.
 - **Privacy:** GPS stops when app backgrounded
 - Built: 2026-03
 

--- a/frontend/app/(tabs)/map.tsx
+++ b/frontend/app/(tabs)/map.tsx
@@ -131,6 +131,7 @@ const SummaryRow = ({ label, value }: SummaryRowProps) => (
 
 const MapScreen = () => {
   const [coords, setCoords] = useState<Coordinates | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
   const [groupId, setGroupId] = useState<string | null>(null);
   const [runSnap, setRunSnap] = useState<RunSnapshot | null>(null);
   const [teammates, setTeammates] = useState<Teammate[]>([]);
@@ -183,13 +184,15 @@ const MapScreen = () => {
     const loadGroup = async () => {
       try {
         const storedGroupId = await AsyncStorage.getItem('groupId');
+        const storedUserId = await AsyncStorage.getItem('userId');
         if (mounted) {
           setGroupId(storedGroupId);
+          setUserId(storedUserId);
           setLoading(false);
         }
         if (storedGroupId) {
-          await fetchTeammates(storedGroupId);
-          interval = setInterval(() => fetchTeammates(storedGroupId), 10000);
+          await fetchTeammates(storedGroupId, storedUserId);
+          interval = setInterval(() => fetchTeammates(storedGroupId, storedUserId), 10000);
         }
       } catch (error) {
         console.error('Failed to load group', error);
@@ -243,18 +246,48 @@ const MapScreen = () => {
     };
   }, []);
 
-  const fetchTeammates = async (activeGroupId: string) => {
+  useEffect(() => {
+    const unsubscribe = wsClient.onLocation((message) => {
+      const incomingUserId = message.user_id || message.userId;
+      const lat = Number(message.lat);
+      const lng = Number(message.lng);
+      if (!incomingUserId || incomingUserId === userId || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+        return;
+      }
+
+      setTeammates((prev) => {
+        const existing = prev.find((m) => m.id === incomingUserId);
+        const updated: Teammate = {
+          id: incomingUserId,
+          name: existing?.name || 'Teammate',
+          latitude: lat,
+          longitude: lng,
+        };
+        if (!existing) {
+          return [...prev, updated];
+        }
+        return prev.map((m) => (m.id === incomingUserId ? { ...m, ...updated } : m));
+      });
+    });
+
+    return unsubscribe;
+  }, [userId]);
+
+  const fetchTeammates = async (activeGroupId: string, currentUserId?: string | null) => {
     try {
-      const response = await api.get(`/api/locations/${activeGroupId}`);
-      const raw: any[] = response.data?.teammates || response.data || [];
+      const response = await api.get(`/api/groups/${activeGroupId}/members`);
+      const raw: any[] = response.data?.members || response.data?.teammates || response.data || [];
       // Normalise backend field names (lat/lng) to frontend interface (latitude/longitude)
       const list: Teammate[] = Array.isArray(raw)
-        ? raw.map((m) => ({
-            id: m.user_id || m.id,
-            name: m.name,
-            latitude: m.latitude ?? m.lat,
-            longitude: m.longitude ?? m.lng,
-          }))
+        ? raw
+            .map((m) => ({
+              id: m.user_id || m.userId || m.id,
+              name: m.name,
+              latitude: Number(m.latitude ?? m.lat),
+              longitude: Number(m.longitude ?? m.lng),
+            }))
+            .filter((m) => m.id && Number.isFinite(Number(m.latitude)) && Number.isFinite(Number(m.longitude)))
+            .filter((m) => m.id !== currentUserId)
         : [];
       setTeammates(list);
       setFetchError(null);

--- a/frontend/app/services/location.ts
+++ b/frontend/app/services/location.ts
@@ -10,6 +10,9 @@ export interface Coordinates {
 }
 
 let locationSubscription: Location.LocationSubscription | null = null;
+let lastWsLocationSentAt = 0;
+
+const MIN_WS_LOCATION_INTERVAL_MS = 3000;
 
 export const requestPermissions = async () => {
   const { status } = await Location.requestForegroundPermissionsAsync();
@@ -42,15 +45,23 @@ export const startLocationTracking = async (onUpdate?: (coords: Coordinates) => 
 
       onUpdate?.(coords);
 
-      if (wsClient.isConnected()) {
-        wsClient.send({
+      const now = Date.now();
+      if (wsClient.isConnected() && now - lastWsLocationSentAt >= MIN_WS_LOCATION_INTERVAL_MS) {
+        lastWsLocationSentAt = now;
+        const payload: Record<string, any> = {
           type: 'location',
           lat: coords.latitude,
           lng: coords.longitude,
-          altitude_m: coords.altitude,
-          speed_ms: coords.speed,
-          ts: Date.now(),
-        });
+          sent_at: now,
+          ts: now,
+        };
+        if (coords.altitude != null) {
+          payload.altitude_m = coords.altitude;
+        }
+        if (coords.speed != null) {
+          payload.speed_ms = coords.speed;
+        }
+        wsClient.send(payload);
       }
     }
   );
@@ -63,4 +74,5 @@ export const stopLocationTracking = () => {
     locationSubscription.remove();
     locationSubscription = null;
   }
+  lastWsLocationSentAt = 0;
 };

--- a/frontend/app/services/ws.ts
+++ b/frontend/app/services/ws.ts
@@ -2,6 +2,48 @@ type Listener = (payload: any) => void;
 
 type ListenerMap = Record<string, Set<Listener>>;
 
+export interface LocationMessage {
+  type: 'location';
+  userId?: string;
+  user_id?: string;
+  lat: number;
+  lng: number;
+  altitude_m?: number | null;
+  speed_ms?: number | null;
+  sent_at?: number | string | null;
+  ts?: number;
+}
+
+export interface PresenceMessage {
+  type: 'member_joined' | 'member_left';
+  userId?: string;
+  user_id?: string;
+  name?: string;
+  online: boolean;
+  last_seen_at?: string | null;
+}
+
+export interface MemberSnapshotMessage {
+  type: 'members_snapshot';
+  groupId: string;
+  members: Array<{
+    user_id?: string;
+    userId?: string;
+    name?: string;
+    online: boolean;
+    last_seen_at?: string | null;
+    lat?: number | null;
+    lng?: number | null;
+    location_updated_at?: string | null;
+  }>;
+}
+
+export interface WebRtcSignalMessage {
+  type: 'webrtc_signal';
+  from_user_id: string;
+  signal: any;
+}
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:8100';
 const WS_URL = API_URL.replace('http', 'ws');
 
@@ -55,6 +97,9 @@ class FlowWebSocket {
       try {
         const data = JSON.parse(event.data);
         this.emit('message', data);
+        if (typeof data?.type === 'string') {
+          this.emit(data.type, data);
+        }
       } catch (error) {
         console.warn('Failed to parse WS message', error);
       }
@@ -150,11 +195,54 @@ class FlowWebSocket {
     return () => this.off('message', listener);
   }
 
-  on(event: string, listener: Listener) {
+  onLocation(handler: (msg: LocationMessage) => void): () => void {
+    const listener = (data: any) => {
+      if (data?.type === 'location') {
+        handler(data as LocationMessage);
+      }
+    };
+    this.on('message', listener);
+    return () => this.off('message', listener);
+  }
+
+  onPresence(handler: (msg: PresenceMessage) => void): () => void {
+    const listener = (data: any) => {
+      if (data?.type === 'member_joined' || data?.type === 'member_left') {
+        handler(data as PresenceMessage);
+      }
+    };
+    this.on('message', listener);
+    return () => this.off('message', listener);
+  }
+
+  onMemberSnapshot(handler: (msg: MemberSnapshotMessage) => void): () => void {
+    const listener = (data: any) => {
+      if (data?.type === 'members_snapshot') {
+        handler(data as MemberSnapshotMessage);
+      }
+    };
+    this.on('message', listener);
+    return () => this.off('message', listener);
+  }
+
+  sendWebRtcSignal(targetUserId: string, signal: any) {
+    this.send({
+      type: 'webrtc_signal',
+      target_user_id: targetUserId,
+      signal,
+    });
+  }
+
+  sendPing(ts = Date.now()) {
+    this.send({ type: 'client_ping', ts });
+  }
+
+  on(event: string, listener: Listener): () => void {
     if (!this.listeners[event]) {
       this.listeners[event] = new Set();
     }
     this.listeners[event].add(listener);
+    return () => this.off(event, listener);
   }
 
   off(event: string, listener: Listener) {


### PR DESCRIPTION
Part of #3.

## Summary
- Adds `members_snapshot` on join with online/last_seen_at roster state.
- Adds `webrtc_signal` relay, requiring joined/authenticated sockets and same-room online targets.
- Adds `client_ping`/`server_pong` support.
- Adds `GET /api/groups/:groupId/members` for REST member fallback with presence and latest location.
- Consumes live WS location messages on the map while keeping REST polling as initial load/fallback.

## Verification
- `cd backend && npm test`