### PR TITLE
feat: #3 PR B — WebRTC Opus intercom (replace Expo AV)

### DIFF
--- a/docs/SPEC_REGISTER.md
+++ b/docs/SPEC_REGISTER.md
@@ -53,3 +53,4 @@
 - [ ] Slope difficulty overlay
 - [ ] Friend system (add/follow/search)
 - [ ] Battery optimization for GPS polling
+- [x] Phase 2 PR B: WebRTC Opus intercom (#70)

--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, FlatList, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as FileSystem from 'expo-file-system/legacy';
-import { Audio, InterruptionModeAndroid, InterruptionModeIOS } from 'expo-av';
 
-import wsClient from '../services/ws';
-import bleBridge from '../services/ble';
+import wsClient, { MemberSnapshotMessage, PresenceMessage, WebRtcSignalMessage } from '../services/ws';
+import { GroupAudioManager } from '../services/groupAudio';
 
 interface Identity {
   userId: string;
@@ -26,15 +24,291 @@ const IntercomScreen = () => {
   const [members, setMembers] = useState<Record<string, MemberState>>({});
   const [activeSpeaker, setActiveSpeaker] = useState<MemberState | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'error' | 'closed'>(wsClient.getState());
-  const [isRecording, setIsRecording] = useState(false);
+  const [isTransmitting, setIsTransmitting] = useState(false);
   const [channelBusy, setChannelBusy] = useState(false);
   const [permissionError, setPermissionError] = useState<string | null>(null);
 
-  const recordingRef = useRef<Audio.Recording | null>(null);
-  const playbackQueue = useRef(Promise.resolve());
+  const groupAudioRef = useRef<GroupAudioManager | null>(null);
+  const pendingPttRef = useRef(false);
+  const recoveryOfferTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const pulseScale = useRef(new Animated.Value(1)).current;
 
   const { userId, groupId, name: displayName } = identity;
+
+  const clearRecoveryTimer = useCallback((peerUserId: string) => {
+    const timer = recoveryOfferTimersRef.current[peerUserId];
+    if (timer) {
+      clearTimeout(timer);
+      delete recoveryOfferTimersRef.current[peerUserId];
+    }
+  }, []);
+
+  const memberIdFromMessage = useCallback((message: any): string | null => {
+    const candidate = message?.userId ?? message?.user_id ?? message?.from_user_id;
+    return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+  }, []);
+
+  const upsertMemberFromPresence = useCallback((message: any, isTalking?: boolean) => {
+    const memberId = memberIdFromMessage(message);
+    if (!memberId) return;
+
+    setMembers((prev) => ({
+      ...prev,
+      [memberId]: {
+        id: memberId,
+        name:
+          message?.name ||
+          prev[memberId]?.name ||
+          (memberId === userId ? displayName || 'You' : 'Teammate'),
+        isTalking: isTalking ?? prev[memberId]?.isTalking ?? false,
+      },
+    }));
+  }, [displayName, memberIdFromMessage, userId]);
+
+  const initializeGroupAudio = useCallback(async (currentIdentity: Identity): Promise<void> => {
+    if (groupAudioRef.current) return;
+
+    const manager = new GroupAudioManager({
+      identity: {
+        userId: currentIdentity.userId,
+        groupId: currentIdentity.groupId,
+        name: currentIdentity.name,
+      },
+      callbacks: {
+        sendSignal: (targetUserId, signal) => wsClient.sendWebRtcSignal(targetUserId, signal),
+        onError: (_peerUserId, error) => {
+          console.warn('[intercom] group audio error:', error.message);
+        },
+      },
+    });
+
+    try {
+      await manager.start();
+      groupAudioRef.current = manager;
+      setPermissionError(null);
+    } catch (error) {
+      manager.dispose();
+      const message = error instanceof Error ? error.message : String(error);
+      setPermissionError(message || 'Unable to access microphone');
+    }
+  }, []);
+
+  const teardownGroupAudio = useCallback(() => {
+    Object.values(recoveryOfferTimersRef.current).forEach((timer) => clearTimeout(timer));
+    recoveryOfferTimersRef.current = {};
+
+    const manager = groupAudioRef.current;
+    groupAudioRef.current = null;
+    manager?.dispose();
+  }, []);
+
+  const startTalking = useCallback(async () => {
+    const manager = groupAudioRef.current;
+    if (!manager || !groupId || connectionStatus !== 'connected' || isTransmitting || channelBusy) return;
+
+    setPermissionError(null);
+    pendingPttRef.current = true;
+    wsClient.send({ type: 'ptt_start', mode: 'ptt' });
+
+    try {
+      await manager.setMicEnabled(true);
+      setIsTransmitting(true);
+      if (userId) {
+        setMembers((prev) => ({
+          ...prev,
+          [userId]: {
+            id: userId,
+            name: displayName || prev[userId]?.name || 'You',
+            isTalking: true,
+          },
+        }));
+        setActiveSpeaker({ id: userId, name: displayName || 'You', isTalking: true });
+      }
+    } catch (error) {
+      pendingPttRef.current = false;
+      await manager.setMicEnabled(false).catch(() => null);
+      wsClient.send({ type: 'ptt_end' });
+      const message = error instanceof Error ? error.message : String(error);
+      setPermissionError(message || 'Unable to access microphone');
+    }
+  }, [channelBusy, connectionStatus, displayName, groupId, isTransmitting, userId]);
+
+  const stopTalking = useCallback(async () => {
+    const manager = groupAudioRef.current;
+    if (!manager && !isTransmitting && !pendingPttRef.current) return;
+
+    pendingPttRef.current = false;
+    if (manager) {
+      await manager.setMicEnabled(false).catch(() => null);
+    }
+    setIsTransmitting(false);
+    wsClient.send({ type: 'ptt_end' });
+
+    if (userId) {
+      setMembers((prev) => {
+        if (!prev[userId]) return prev;
+        return {
+          ...prev,
+          [userId]: {
+            ...prev[userId],
+            isTalking: false,
+          },
+        };
+      });
+      setActiveSpeaker((current) => (current && current.id === userId ? null : current));
+    }
+  }, [isTransmitting, userId]);
+
+  const handleMemberSnapshot = useCallback((message: MemberSnapshotMessage) => {
+    const manager = groupAudioRef.current;
+    const onlineMembers = (message.members || []).filter((member) => member.online);
+
+    setMembers((prev) => {
+      const next: Record<string, MemberState> = {};
+      onlineMembers.forEach((member) => {
+        const memberId = member.user_id || member.userId;
+        if (!memberId) return;
+        next[memberId] = {
+          id: memberId,
+          name: member.name || prev[memberId]?.name || (memberId === userId ? displayName || 'You' : 'Teammate'),
+          isTalking: prev[memberId]?.isTalking ?? false,
+        };
+      });
+
+      if (userId && !next[userId]) {
+        next[userId] = {
+          id: userId,
+          name: displayName || prev[userId]?.name || 'You',
+          isTalking: prev[userId]?.isTalking ?? false,
+        };
+      }
+
+      return next;
+    });
+
+    onlineMembers.forEach((member) => {
+      const memberId = member.user_id || member.userId;
+      if (!memberId || memberId === userId || !manager) return;
+
+      manager.ensurePeer({ userId: memberId, name: member.name }, { createOffer: false }).catch((error) => {
+        console.warn('[intercom] ensurePeer from snapshot failed:', error);
+      });
+
+      clearRecoveryTimer(memberId);
+      if (userId < memberId) {
+        recoveryOfferTimersRef.current[memberId] = setTimeout(() => {
+          manager.ensurePeer({ userId: memberId, name: member.name }, { createOffer: true }).catch((error) => {
+            console.warn('[intercom] delayed recovery offer failed:', error);
+          });
+          clearRecoveryTimer(memberId);
+        }, 1200);
+      }
+    });
+  }, [clearRecoveryTimer, displayName, userId]);
+
+  const handlePresence = useCallback((message: PresenceMessage) => {
+    const manager = groupAudioRef.current;
+    const memberId = memberIdFromMessage(message);
+    if (!memberId) return;
+
+    if (message.type === 'member_joined') {
+      upsertMemberFromPresence(message, false);
+      if (memberId !== userId && manager) {
+        manager.ensurePeer({ userId: memberId, name: message.name }, { createOffer: true }).catch((error) => {
+          console.warn('[intercom] ensurePeer on join failed:', error);
+        });
+      }
+      return;
+    }
+
+    if (message.type === 'member_left') {
+      setMembers((prev) => {
+        const next = { ...prev };
+        delete next[memberId];
+        return next;
+      });
+      setActiveSpeaker((current) => (current && current.id === memberId ? null : current));
+      clearRecoveryTimer(memberId);
+      manager?.removePeer(memberId);
+    }
+  }, [clearRecoveryTimer, memberIdFromMessage, upsertMemberFromPresence, userId]);
+
+  const handleWebRtcSignal = useCallback((message: WebRtcSignalMessage) => {
+    const manager = groupAudioRef.current;
+    if (!manager || !message?.from_user_id || !message.signal) return;
+
+    manager.handleSignal(message.from_user_id, message.signal).catch((error) => {
+      console.warn('[intercom] handleSignal failed:', error);
+    });
+  }, []);
+
+  const handleMessage = useCallback((message: any) => {
+    if (!message?.type) return;
+
+    switch (message.type) {
+      case 'members_snapshot':
+        handleMemberSnapshot(message as MemberSnapshotMessage);
+        break;
+      case 'member_joined':
+      case 'member_left':
+        handlePresence(message as PresenceMessage);
+        break;
+      case 'webrtc_signal':
+        handleWebRtcSignal(message as WebRtcSignalMessage);
+        break;
+      case 'ptt_start': {
+        const senderId = memberIdFromMessage(message);
+        if (!senderId) return;
+        upsertMemberFromPresence(message, true);
+        setActiveSpeaker({
+          id: senderId,
+          name: message?.name || (senderId === userId ? displayName || 'You' : 'Teammate'),
+          isTalking: true,
+        });
+        break;
+      }
+      case 'ptt_end': {
+        const senderId = memberIdFromMessage(message);
+        if (!senderId) return;
+        setMembers((prev) => {
+          if (!prev[senderId]) return prev;
+          return {
+            ...prev,
+            [senderId]: {
+              ...prev[senderId],
+              isTalking: false,
+            },
+          };
+        });
+        setActiveSpeaker((current) => (current && current.id === senderId ? null : current));
+        setChannelBusy(false);
+        break;
+      }
+      case 'ptt_busy': {
+        setChannelBusy(true);
+        pendingPttRef.current = false;
+        groupAudioRef.current?.setMicEnabled(false).catch(() => null);
+        setIsTransmitting(false);
+        setActiveSpeaker(null);
+        if (userId) {
+          setMembers((prev) => {
+            if (!prev[userId]) return prev;
+            return {
+              ...prev,
+              [userId]: {
+                ...prev[userId],
+                isTalking: false,
+              },
+            };
+          });
+        }
+        setTimeout(() => setChannelBusy(false), 3000);
+        break;
+      }
+      default:
+        break;
+    }
+  }, [displayName, handleMemberSnapshot, handlePresence, handleWebRtcSignal, memberIdFromMessage, upsertMemberFromPresence, userId]);
 
   useEffect(() => {
     let mounted = true;
@@ -47,7 +321,7 @@ const IntercomScreen = () => {
         setIdentity({
           userId: (values.userId as string) || '',
           groupId: (values.groupId as string) || '',
-          name: (values.displayName as string) || ''
+          name: (values.displayName as string) || '',
         });
       } catch (error) {
         console.warn('Failed to load intercom identity', error);
@@ -67,7 +341,7 @@ const IntercomScreen = () => {
     return () => {
       wsClient.disconnect();
     };
-  }, [userId, groupId, displayName]);
+  }, [displayName, groupId, userId]);
 
   useEffect(() => {
     if (!userId) return;
@@ -76,133 +350,24 @@ const IntercomScreen = () => {
       [userId]: {
         id: userId,
         name: displayName || prev[userId]?.name || 'You',
-        isTalking: prev[userId]?.isTalking ?? false
-      }
+        isTalking: prev[userId]?.isTalking ?? false,
+      },
     }));
   }, [displayName, userId]);
 
   useEffect(() => {
-    return () => {
-      if (recordingRef.current) {
-        recordingRef.current.stopAndUnloadAsync().catch(() => null);
-      }
-    };
-  }, []);
-
-  const enqueuePlayback = useCallback((base64Data: string) => {
-    if (!base64Data) return;
-    playbackQueue.current = playbackQueue.current.then(async () => {
-      const cacheDir = FileSystem.cacheDirectory ?? '';
-      const tempFile = `${cacheDir}ptt-${Date.now()}-${Math.random().toString(36).slice(2)}.aac`;
-      try {
-        await FileSystem.writeAsStringAsync(tempFile, base64Data, {
-          encoding: FileSystem.EncodingType.Base64
-        });
-        // Switch audio session to playback mode before playing
-        await Audio.setAudioModeAsync({
-          allowsRecordingIOS: false,
-          playsInSilentModeIOS: true,
-          interruptionModeIOS: InterruptionModeIOS.DoNotMix,
-          interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
-          shouldDuckAndroid: true,
-          playThroughEarpieceAndroid: false,
-          staysActiveInBackground: false,
-        });
-        const { sound } = await Audio.Sound.createAsync(
-          { uri: tempFile },
-          { shouldPlay: true }  // play immediately on load
-        );
-        await new Promise<void>((resolve) => {
-          sound.setOnPlaybackStatusUpdate((status) => {
-            if (!status.isLoaded) return;
-            if (status.didJustFinish) {  // only resolve when actually finished
-              sound.setOnPlaybackStatusUpdate(null);
-              resolve();
-            }
-          });
-        });
-        await sound.unloadAsync();
-      } catch (error) {
-        console.warn('Failed to play audio chunk', error);
-      } finally {
-        await FileSystem.deleteAsync(tempFile, { idempotent: true }).catch(() => null);
-      }
+    if (!userId || !groupId || connectionStatus !== 'connected') return;
+    initializeGroupAudio(identity).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setPermissionError(message || 'Unable to initialize audio');
     });
-  }, []);
+  }, [connectionStatus, groupId, identity, initializeGroupAudio, userId]);
 
-  const handleMessage = useCallback((message: any) => {
-    if (!message?.type) return;
-    const { userId: senderId, name } = message;
-
-    switch (message.type) {
-      case 'member_joined':
-        if (!senderId) return;
-        setMembers((prev) => ({
-          ...prev,
-          [senderId]: {
-            id: senderId,
-            name: name || prev[senderId]?.name || 'Teammate',
-            isTalking: prev[senderId]?.isTalking ?? false
-          }
-        }));
-        break;
-      case 'member_left':
-        if (!senderId) return;
-        setMembers((prev) => {
-          const next = { ...prev };
-          delete next[senderId];
-          return next;
-        });
-        setActiveSpeaker((current) => (current && current.id === senderId ? null : current));
-        break;
-      case 'ptt_start':
-        if (!senderId) return;
-        setMembers((prev) => ({
-          ...prev,
-          [senderId]: {
-            id: senderId,
-            name: name || prev[senderId]?.name || 'Teammate',
-            isTalking: true
-          }
-        }));
-        setActiveSpeaker({ id: senderId, name: name || 'Teammate', isTalking: true });
-        break;
-      case 'ptt_end':
-        if (!senderId) return;
-        setMembers((prev) => {
-          if (!prev[senderId]) return prev;
-          return {
-            ...prev,
-            [senderId]: {
-              ...prev[senderId],
-              isTalking: false
-            }
-          };
-        });
-        setActiveSpeaker((current) => (current && current.id === senderId ? null : current));
-        setChannelBusy(false);
-        break;
-      case 'ptt_busy':
-        // Another user holds the channel floor — stop local recording
-        setIsRecording(false);
-        setChannelBusy(true);
-        setTimeout(() => setChannelBusy(false), 3000);
-        if (recordingRef.current) {
-          recordingRef.current.stopAndUnloadAsync().catch(() => null);
-          recordingRef.current = null;
-        }
-        // Clear any active speaker indicator — channel is busy with another user
-        setActiveSpeaker(null);
-        break;
-      case 'audio_chunk':
-        if (typeof message.data === 'string') {
-          enqueuePlayback(message.data);
-        }
-        break;
-      default:
-        break;
-    }
-  }, [enqueuePlayback]);
+  useEffect(() => {
+    return () => {
+      teardownGroupAudio();
+    };
+  }, [teardownGroupAudio]);
 
   useEffect(() => {
     const statusListener = (payload: any) => {
@@ -224,7 +389,7 @@ const IntercomScreen = () => {
       animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseScale, { toValue: 1.1, duration: 500, useNativeDriver: true }),
-          Animated.timing(pulseScale, { toValue: 1, duration: 500, useNativeDriver: true })
+          Animated.timing(pulseScale, { toValue: 1, duration: 500, useNativeDriver: true }),
         ])
       );
       animation.start();
@@ -236,126 +401,6 @@ const IntercomScreen = () => {
       animation?.stop();
     };
   }, [activeSpeaker, pulseScale]);
-
-  const startRecording = useCallback(async () => {
-    if (isRecording || !groupId || connectionStatus !== 'connected') return;
-    try {
-      setPermissionError(null);
-      const permission = await Audio.requestPermissionsAsync();
-      if (permission.status !== 'granted') {
-        setPermissionError('Microphone permission denied');
-        return;
-      }
-
-      await Audio.setAudioModeAsync({
-        allowsRecordingIOS: true,
-        playsInSilentModeIOS: true,
-        interruptionModeIOS: InterruptionModeIOS.DoNotMix,
-        interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
-        shouldDuckAndroid: true,
-        playThroughEarpieceAndroid: false,
-        staysActiveInBackground: false
-      });
-
-      const recording = new Audio.Recording();
-      await recording.prepareToRecordAsync({
-        isMeteringEnabled: false,
-        android: {
-          extension: '.aac',
-          outputFormat: Audio.AndroidOutputFormat.AAC_ADTS,
-          audioEncoder: Audio.AndroidAudioEncoder.AAC,
-          sampleRate: 16000,
-          numberOfChannels: 1,
-          bitRate: 32000,
-        },
-        ios: {
-          extension: '.aac',
-          outputFormat: Audio.IOSOutputFormat.MPEG4AAC,
-          audioQuality: Audio.IOSAudioQuality.MEDIUM,
-          sampleRate: 16000,
-          numberOfChannels: 1,
-          bitRate: 32000,
-          linearPCMBitDepth: 16,
-          linearPCMIsBigEndian: false,
-          linearPCMIsFloat: false,
-        },
-        web: {
-          mimeType: 'audio/webm',
-          bitsPerSecond: 32000,
-        },
-      });
-      await recording.startAsync();
-      recordingRef.current = recording;
-      setIsRecording(true);
-
-      wsClient.send({ type: 'ptt_start' });
-      if (userId) {
-        setMembers((prev) => ({
-          ...prev,
-          [userId]: {
-            id: userId,
-            name: displayName || prev[userId]?.name || 'You',
-            isTalking: true
-          }
-        }));
-        setActiveSpeaker({ id: userId, name: displayName || 'You', isTalking: true });
-      }
-    } catch (error) {
-      console.error('Failed to start recording', error);
-      setPermissionError('Unable to access microphone');
-    }
-  }, [connectionStatus, displayName, groupId, isRecording, userId]);
-
-  const stopRecording = useCallback(async () => {
-    const activeRecording = recordingRef.current;
-    if (!activeRecording && !isRecording) return;
-
-    try {
-      if (activeRecording) {
-        await activeRecording.stopAndUnloadAsync();
-        const uri = activeRecording.getURI();
-        if (uri) {
-          const base64 = await FileSystem.readAsStringAsync(uri, {
-            encoding: FileSystem.EncodingType.Base64
-          });
-          if (base64) {
-            wsClient.send({ type: 'audio_chunk', data: base64 });
-            bleBridge.mirrorPttChunk(base64);
-          }
-          await FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => null);
-        }
-      }
-    } catch (error) {
-      console.error('Failed to stop recording', error);
-    } finally {
-      recordingRef.current = null;
-      setIsRecording(false);
-      // Restore audio session to playback mode so incoming audio can be heard
-      Audio.setAudioModeAsync({
-        allowsRecordingIOS: false,
-        playsInSilentModeIOS: true,
-        interruptionModeIOS: InterruptionModeIOS.DoNotMix,
-        interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
-        shouldDuckAndroid: true,
-        playThroughEarpieceAndroid: false,
-        staysActiveInBackground: false,
-      }).catch(() => null);
-      wsClient.send({ type: 'ptt_end' });
-      if (userId) {
-        setMembers((prev) => {
-          if (!prev[userId]) return prev;
-          return {
-            ...prev,
-            [userId]: {
-              ...prev[userId],
-              isTalking: false
-            }
-          };
-        });
-        setActiveSpeaker((current) => (current && current.id === userId ? null : current));
-      }
-    }
-  }, [isRecording, userId]);
 
   const buttonDisabled = !groupId || connectionStatus !== 'connected';
 
@@ -420,7 +465,6 @@ const IntercomScreen = () => {
         </View>
       </ScrollView>
 
-      {/* PTT controls fixed to bottom — never scrolls off-screen (#34) */}
       <View style={styles.controls}>
         {channelBusy ? (
           <Text style={styles.busyText}>Channel busy — someone else is talking</Text>
@@ -428,16 +472,16 @@ const IntercomScreen = () => {
           <Text style={styles.status}>{statusText}</Text>
         )}
         <Pressable
-          onPressIn={startRecording}
-          onPressOut={stopRecording}
+          onPressIn={startTalking}
+          onPressOut={stopTalking}
           disabled={buttonDisabled}
           style={({ pressed }) => [
             styles.pttButton,
-            (isRecording || pressed) && styles.pttButtonActive,
-            buttonDisabled && styles.pttButtonDisabled
+            (isTransmitting || pressed) && styles.pttButtonActive,
+            buttonDisabled && styles.pttButtonDisabled,
           ]}
         >
-          <Text style={styles.pttLabel}>{isRecording ? 'RELEASE TO SEND' : 'HOLD TO TALK'}</Text>
+          <Text style={styles.pttLabel}>{isTransmitting ? 'RELEASE TO SEND' : 'HOLD TO TALK'}</Text>
         </Pressable>
         {permissionError ? <Text style={styles.errorText}>{permissionError}</Text> : null}
       </View>
@@ -448,15 +492,15 @@ const IntercomScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#06121f'
+    backgroundColor: '#06121f',
   },
   scrollArea: {
-    flex: 1
+    flex: 1,
   },
   scrollContent: {
     padding: 16,
     gap: 16,
-    paddingBottom: 100 // space for bottom PTT bar
+    paddingBottom: 100,
   },
   infoBanner: {
     backgroundColor: '#0d2034',
@@ -464,22 +508,22 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 14,
     borderLeftWidth: 3,
-    borderLeftColor: '#1e88e5'
+    borderLeftColor: '#1e88e5',
   },
   infoText: {
     color: '#9fb4cc',
-    fontSize: 13
+    fontSize: 13,
   },
   card: {
     backgroundColor: '#10243b',
     borderRadius: 16,
-    padding: 16
+    padding: 16,
   },
   heading: {
     color: '#fff',
     fontSize: 18,
     fontWeight: '700',
-    marginBottom: 12
+    marginBottom: 12,
   },
   memberRow: {
     flexDirection: 'row',
@@ -487,56 +531,56 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 12,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#1e3a5f'
+    borderBottomColor: '#1e3a5f',
   },
   memberInfo: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8
+    gap: 8,
   },
   onlineDot: {
     width: 10,
     height: 10,
     borderRadius: 5,
-    backgroundColor: '#4caf50'
+    backgroundColor: '#4caf50',
   },
   memberName: {
     color: '#fff',
     fontSize: 16,
-    fontWeight: '600'
+    fontWeight: '600',
   },
   memberStatus: {
     color: '#9fb4cc',
-    fontSize: 14
+    fontSize: 14,
   },
   waveform: {
     flexDirection: 'row',
     alignItems: 'flex-end',
-    gap: 4
+    gap: 4,
   },
   waveBar: {
     width: 6,
     height: 12,
     borderRadius: 3,
-    backgroundColor: '#ff9800'
+    backgroundColor: '#ff9800',
   },
   waveBarTall: {
-    height: 20
+    height: 20,
   },
   emptyText: {
     color: '#7f8ea3',
     textAlign: 'center',
-    marginTop: 8
+    marginTop: 8,
   },
   speakerCard: {
     backgroundColor: '#0d2034',
     borderRadius: 16,
-    padding: 16
+    padding: 16,
   },
   speakerRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 16
+    gap: 16,
   },
   pulseCircle: {
     width: 32,
@@ -545,12 +589,12 @@ const styles = StyleSheet.create({
     backgroundColor: '#ff9800',
     shadowColor: '#ff9800',
     shadowOpacity: 0.7,
-    shadowRadius: 14
+    shadowRadius: 14,
   },
   speakerName: {
     color: '#fff',
     fontSize: 18,
-    fontWeight: '700'
+    fontWeight: '700',
   },
   controls: {
     alignItems: 'center',
@@ -559,16 +603,16 @@ const styles = StyleSheet.create({
     paddingBottom: 16,
     backgroundColor: '#06121f',
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: '#1e3a5f'
+    borderTopColor: '#1e3a5f',
   },
   status: {
-    color: '#9fb4cc'
+    color: '#9fb4cc',
   },
   busyText: {
     color: '#ff9800',
     fontWeight: '600',
     fontSize: 14,
-    textAlign: 'center'
+    textAlign: 'center',
   },
   pttButton: {
     width: 180,
@@ -579,22 +623,22 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     shadowColor: '#1e88e5',
     shadowOpacity: 0.6,
-    shadowRadius: 20
+    shadowRadius: 20,
   },
   pttButtonActive: {
-    backgroundColor: '#1565c0'
+    backgroundColor: '#1565c0',
   },
   pttButtonDisabled: {
-    opacity: 0.4
+    opacity: 0.4,
   },
   pttLabel: {
     color: '#fff',
     fontWeight: '700',
-    fontSize: 18
+    fontSize: 18,
   },
   errorText: {
-    color: '#ff8a80'
-  }
+    color: '#ff8a80',
+  },
 });
 
 export default IntercomScreen;

--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -214,7 +214,10 @@ const IntercomScreen = () => {
     if (message.type === 'member_joined') {
       upsertMemberFromPresence(message, false);
       if (memberId !== userId && manager) {
-        manager.ensurePeer({ userId: memberId, name: message.name }, { createOffer: true }).catch((error) => {
+        // Only create offer if we're lexicographically smaller —
+        // the smaller userId takes initiative to avoid glare.
+        const createOffer = userId < memberId;
+        manager.ensurePeer({ userId: memberId, name: message.name }, { createOffer }).catch((error) => {
           console.warn('[intercom] ensurePeer on join failed:', error);
         });
       }

--- a/frontend/app/services/groupAudio.ts
+++ b/frontend/app/services/groupAudio.ts
@@ -243,6 +243,33 @@ export class GroupAudioManager {
 
     try {
       if (signal.kind === 'offer') {
+        const isStable = (anyPc.signalingState === 'stable');
+
+        // Perfect Negotiation: if both sides create offers at once (glare),
+        // the lexicographically smaller userId keeps its offer;
+        // the larger yields and accepts the incoming offer.
+        if (!isStable) {
+          if (peer.makingOffer && this.identity.userId > fromUserId) {
+            // We yield — roll back our in-progress offer and accept theirs.
+            peer.makingOffer = false;
+            await anyPc.setRemoteDescription(
+              new RTCSessionDescription({ type: 'offer', sdp: signal.sdp })
+            );
+            peer.remoteDescriptionSet = true;
+            await this.drainIceQueue(peer);
+            const answer = await anyPc.createAnswer();
+            await anyPc.setLocalDescription(answer);
+            const sdp = String(anyPc.localDescription?.sdp || answer?.sdp || '');
+            if (sdp) {
+              this.callbacks.sendSignal(fromUserId, { kind: 'answer', sdp });
+            }
+            return;
+          }
+          // We have initiative or someone else is already in-flight —
+          // politely ignore this offer. The peer will retry if needed.
+          return;
+        }
+
         await anyPc.setRemoteDescription(new RTCSessionDescription({ type: 'offer', sdp: signal.sdp }));
         peer.remoteDescriptionSet = true;
         await this.drainIceQueue(peer);

--- a/frontend/app/services/groupAudio.ts
+++ b/frontend/app/services/groupAudio.ts
@@ -1,0 +1,394 @@
+import {
+  MediaStream,
+  MediaStreamTrack,
+  RTCPeerConnection,
+  RTCSessionDescription,
+  RTCIceCandidate,
+  mediaDevices,
+} from 'react-native-webrtc';
+
+export type SignalTier = 'excellent' | 'good' | 'fair' | 'poor';
+export type AudioBitrateBps = 6000 | 12000 | 18000 | 24000;
+
+export type GroupAudioSignal =
+  | { kind: 'offer'; sdp: string }
+  | { kind: 'answer'; sdp: string }
+  | { kind: 'ice'; candidate: any };
+
+export interface GroupAudioIdentity {
+  userId: string;
+  groupId: string;
+  name?: string;
+}
+
+export interface GroupAudioPeer {
+  userId: string;
+  name?: string;
+}
+
+export interface GroupAudioCallbacks {
+  sendSignal: (targetUserId: string, signal: GroupAudioSignal) => void;
+  onRemoteStream?: (peerUserId: string, stream: MediaStream) => void;
+  onPeerState?: (peerUserId: string, state: string) => void;
+  onSpeakingTrack?: (peerUserId: string, enabled: boolean) => void;
+  onError?: (peerUserId: string | null, error: Error) => void;
+}
+
+export interface GroupAudioManagerOptions {
+  identity: GroupAudioIdentity;
+  callbacks: GroupAudioCallbacks;
+  initialSignalTier?: SignalTier;
+}
+
+interface PeerRecord {
+  userId: string;
+  name?: string;
+  pc: RTCPeerConnection;
+  remoteStream?: MediaStream;
+  iceQueue: any[];
+  makingOffer: boolean;
+  remoteDescriptionSet: boolean;
+  senderTrack?: MediaStreamTrack;
+}
+
+const ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }];
+
+export function bitrateForSignalTier(tier: SignalTier): AudioBitrateBps {
+  switch (tier) {
+    case 'excellent':
+      return 24000;
+    case 'good':
+      return 18000;
+    case 'fair':
+      return 12000;
+    case 'poor':
+    default:
+      return 6000;
+  }
+}
+
+function normalizeSignalTier(tier?: SignalTier): SignalTier {
+  if (tier === 'excellent' || tier === 'good' || tier === 'fair' || tier === 'poor') {
+    return tier;
+  }
+  return 'good';
+}
+
+function createPeerConnection(): RTCPeerConnection {
+  return new RTCPeerConnection({ iceServers: ICE_SERVERS } as any);
+}
+
+function isGroupAudioSignal(value: any): value is GroupAudioSignal {
+  if (!value || typeof value !== 'object' || typeof value.kind !== 'string') return false;
+  if (value.kind === 'offer' || value.kind === 'answer') {
+    return typeof value.sdp === 'string' && value.sdp.length > 0;
+  }
+  if (value.kind === 'ice') {
+    return value.candidate != null;
+  }
+  return false;
+}
+
+async function getOrCreateLocalAudioStream(): Promise<MediaStream> {
+  return mediaDevices.getUserMedia({
+    audio: {
+      channelCount: 1,
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    } as any,
+    video: false,
+  } as any);
+}
+
+function setTrackEnabled(stream: MediaStream | null, enabled: boolean): void {
+  if (!stream) return;
+  stream.getAudioTracks().forEach((track) => {
+    track.enabled = enabled;
+  });
+}
+
+function preferOpus(pc: RTCPeerConnection): void {
+  const anyPc = pc as any;
+  const transceivers = typeof anyPc.getTransceivers === 'function' ? anyPc.getTransceivers() : [];
+  const firstAudio = transceivers.find((t: any) => t?.sender?.track?.kind === 'audio' || t?.receiver?.track?.kind === 'audio');
+  if (!firstAudio || typeof firstAudio.setCodecPreferences !== 'function') {
+    return;
+  }
+
+  const caps = typeof (globalThis as any).RTCRtpReceiver?.getCapabilities === 'function'
+    ? (globalThis as any).RTCRtpReceiver.getCapabilities('audio')
+    : null;
+  const codecs = Array.isArray(caps?.codecs) ? caps.codecs.slice() : [];
+  if (!codecs.length) return;
+
+  const opus = codecs.filter((codec: any) => {
+    const mimeType = String(codec?.mimeType || '').toLowerCase();
+    return mimeType === 'audio/opus' || mimeType.endsWith('/opus');
+  });
+  if (!opus.length) return;
+
+  const remaining = codecs.filter((codec: any) => !opus.includes(codec));
+  firstAudio.setCodecPreferences([...opus, ...remaining]);
+}
+
+async function applySenderBitrate(pc: RTCPeerConnection, bitrateBps: AudioBitrateBps): Promise<void> {
+  const anyPc = pc as any;
+  const senders = typeof anyPc.getSenders === 'function' ? anyPc.getSenders() : [];
+  const audioSender = senders.find((sender: any) => sender?.track?.kind === 'audio');
+  if (!audioSender || typeof audioSender.getParameters !== 'function' || typeof audioSender.setParameters !== 'function') {
+    return;
+  }
+
+  const parameters = audioSender.getParameters() || {};
+  const encodings = Array.isArray(parameters.encodings) ? parameters.encodings.slice() : [{}];
+  if (!encodings[0]) encodings[0] = {};
+  encodings[0] = {
+    ...encodings[0],
+    maxBitrate: bitrateBps,
+  };
+
+  await audioSender.setParameters({
+    ...parameters,
+    encodings,
+  });
+}
+
+function closePeer(peer: PeerRecord): void {
+  try {
+    (peer.pc as any).onicecandidate = null;
+    (peer.pc as any).ontrack = null;
+    (peer.pc as any).onconnectionstatechange = null;
+    peer.pc.close();
+  } catch {
+    // no-op
+  }
+  peer.iceQueue = [];
+}
+
+export class GroupAudioManager {
+  private readonly identity: GroupAudioIdentity;
+
+  private readonly callbacks: GroupAudioCallbacks;
+
+  private peers = new Map<string, PeerRecord>();
+
+  private localStream: MediaStream | null = null;
+
+  private signalTier: SignalTier;
+
+  private bitrate: AudioBitrateBps;
+
+  private disposed = false;
+
+  constructor(options: GroupAudioManagerOptions) {
+    this.identity = options.identity;
+    this.callbacks = options.callbacks;
+    this.signalTier = normalizeSignalTier(options.initialSignalTier);
+    this.bitrate = bitrateForSignalTier(this.signalTier);
+  }
+
+  async start(): Promise<void> {
+    if (this.disposed) return;
+    if (!this.localStream) {
+      this.localStream = await getOrCreateLocalAudioStream();
+      setTrackEnabled(this.localStream, false);
+    }
+  }
+
+  async ensurePeer(peer: GroupAudioPeer, options?: { createOffer?: boolean }): Promise<void> {
+    if (this.disposed || !peer?.userId || peer.userId === this.identity.userId) return;
+
+    await this.start();
+    const record = this.getOrCreatePeer(peer);
+
+    if (!options?.createOffer) return;
+
+    const anyPc = record.pc as any;
+    if (record.makingOffer || record.remoteDescriptionSet || anyPc.signalingState !== 'stable') {
+      return;
+    }
+
+    try {
+      record.makingOffer = true;
+      const offer = await anyPc.createOffer({
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: false,
+      });
+      await anyPc.setLocalDescription(offer);
+      const sdp = String(anyPc.localDescription?.sdp || offer?.sdp || '');
+      if (!sdp) return;
+      this.callbacks.sendSignal(peer.userId, { kind: 'offer', sdp });
+    } catch (error) {
+      this.emitError(peer.userId, error);
+    } finally {
+      record.makingOffer = false;
+    }
+  }
+
+  removePeer(peerUserId: string): void {
+    const peer = this.peers.get(peerUserId);
+    if (!peer) return;
+    this.peers.delete(peerUserId);
+    closePeer(peer);
+  }
+
+  async handleSignal(fromUserId: string, signal: GroupAudioSignal): Promise<void> {
+    if (this.disposed || !fromUserId || fromUserId === this.identity.userId) return;
+    if (!isGroupAudioSignal(signal)) return;
+
+    await this.start();
+    const peer = this.getOrCreatePeer({ userId: fromUserId });
+    const anyPc = peer.pc as any;
+
+    try {
+      if (signal.kind === 'offer') {
+        await anyPc.setRemoteDescription(new RTCSessionDescription({ type: 'offer', sdp: signal.sdp }));
+        peer.remoteDescriptionSet = true;
+        await this.drainIceQueue(peer);
+
+        const answer = await anyPc.createAnswer();
+        await anyPc.setLocalDescription(answer);
+        const sdp = String(anyPc.localDescription?.sdp || answer?.sdp || '');
+        if (sdp) {
+          this.callbacks.sendSignal(fromUserId, { kind: 'answer', sdp });
+        }
+        return;
+      }
+
+      if (signal.kind === 'answer') {
+        await anyPc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp: signal.sdp }));
+        peer.remoteDescriptionSet = true;
+        await this.drainIceQueue(peer);
+        return;
+      }
+
+      if (signal.kind === 'ice') {
+        if (peer.remoteDescriptionSet) {
+          await anyPc.addIceCandidate(new RTCIceCandidate(signal.candidate));
+        } else {
+          peer.iceQueue.push(signal.candidate);
+        }
+      }
+    } catch (error) {
+      this.emitError(fromUserId, error);
+    }
+  }
+
+  async setMicEnabled(enabled: boolean): Promise<void> {
+    await this.start();
+    setTrackEnabled(this.localStream, enabled);
+  }
+
+  async setSignalTier(tier: SignalTier): Promise<void> {
+    this.signalTier = normalizeSignalTier(tier);
+    this.bitrate = bitrateForSignalTier(this.signalTier);
+    const peers = Array.from(this.peers.values());
+    await Promise.all(peers.map(async (peer) => {
+      try {
+        await applySenderBitrate(peer.pc, this.bitrate);
+      } catch (error) {
+        this.emitError(peer.userId, error);
+      }
+    }));
+  }
+
+  getBitrate(): AudioBitrateBps {
+    return this.bitrate;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    this.peers.forEach((peer) => closePeer(peer));
+    this.peers.clear();
+
+    if (this.localStream) {
+      this.localStream.getTracks().forEach((track) => {
+        try {
+          track.stop();
+        } catch {
+          // no-op
+        }
+      });
+      this.localStream = null;
+    }
+  }
+
+  private getOrCreatePeer(peer: GroupAudioPeer): PeerRecord {
+    const existing = this.peers.get(peer.userId);
+    if (existing) {
+      existing.name = peer.name ?? existing.name;
+      return existing;
+    }
+
+    const pc = createPeerConnection();
+
+    const record: PeerRecord = {
+      userId: peer.userId,
+      name: peer.name,
+      pc,
+      iceQueue: [],
+      makingOffer: false,
+      remoteDescriptionSet: false,
+    };
+
+    (pc as any).onicecandidate = (event: any) => {
+      if (!event?.candidate) return;
+      this.callbacks.sendSignal(peer.userId, {
+        kind: 'ice',
+        candidate: event.candidate,
+      });
+    };
+
+    (pc as any).ontrack = (event: any) => {
+      const stream = event?.streams?.[0];
+      if (!stream) return;
+      record.remoteStream = stream;
+      this.callbacks.onRemoteStream?.(peer.userId, stream);
+      stream.getAudioTracks().forEach((track) => {
+        this.callbacks.onSpeakingTrack?.(peer.userId, !!track.enabled);
+      });
+    };
+
+    (pc as any).onconnectionstatechange = () => {
+      const state = String((pc as any).connectionState || 'unknown');
+      this.callbacks.onPeerState?.(peer.userId, state);
+    };
+
+    if (this.localStream) {
+      const audioTrack = this.localStream.getAudioTracks()[0];
+      if (audioTrack) {
+        record.senderTrack = audioTrack;
+        pc.addTrack(audioTrack, this.localStream);
+      }
+    }
+
+    preferOpus(pc);
+    applySenderBitrate(pc, this.bitrate).catch((error) => {
+      this.emitError(peer.userId, error);
+    });
+
+    this.peers.set(peer.userId, record);
+    return record;
+  }
+
+  private async drainIceQueue(peer: PeerRecord): Promise<void> {
+    if (!peer.iceQueue.length) return;
+
+    const queue = peer.iceQueue.splice(0, peer.iceQueue.length);
+    await Promise.all(queue.map(async (candidate) => {
+      try {
+        await (peer.pc as any).addIceCandidate(new RTCIceCandidate(candidate));
+      } catch (error) {
+        this.emitError(peer.userId, error);
+      }
+    }));
+  }
+
+  private emitError(peerUserId: string | null, rawError: unknown): void {
+    const error = rawError instanceof Error ? rawError : new Error(String(rawError));
+    this.callbacks.onError?.(peerUserId, error);
+  }
+}

--- a/frontend/app/services/groupAudio.ts
+++ b/frontend/app/services/groupAudio.ts
@@ -379,7 +379,7 @@ export class GroupAudioManager {
       if (!stream) return;
       record.remoteStream = stream;
       this.callbacks.onRemoteStream?.(peer.userId, stream);
-      stream.getAudioTracks().forEach((track) => {
+      stream.getAudioTracks().forEach((track: MediaStreamTrack) => {
         this.callbacks.onSpeakingTrack?.(peer.userId, !!track.enabled);
       });
     };

--- a/frontend/app/services/groupAudio.ts
+++ b/frontend/app/services/groupAudio.ts
@@ -245,17 +245,22 @@ export class GroupAudioManager {
       if (signal.kind === 'offer') {
         const isStable = (anyPc.signalingState === 'stable');
 
-        // Perfect Negotiation: if both sides create offers at once (glare),
-        // the lexicographically smaller userId keeps its offer;
-        // the larger yields and accepts the incoming offer.
-        if (!isStable) {
-          if (peer.makingOffer && this.identity.userId > fromUserId) {
-            // We yield — roll back our in-progress offer and accept theirs.
-            peer.makingOffer = false;
+        // Perfect Negotiation glare handling: if we have a local offer
+        // in flight when a remote offer arrives, the lexicographically
+        // smaller userId keeps its offer; the larger rolls back and
+        // accepts. (We check signalingState instead of peer.makingOffer
+        // because makingOffer is already false by the time the remote
+        // offer reaches us via WS relay.)
+        if (!isStable && anyPc.signalingState === 'have-local-offer') {
+          if (this.identity.userId > fromUserId) {
+            // We have the larger userId — roll back and accept.
+            // Rollback via setLocalDescription({ type: 'rollback' }) or
+            // by setting remote desc first (Chrome-compatible path).
             await anyPc.setRemoteDescription(
               new RTCSessionDescription({ type: 'offer', sdp: signal.sdp })
             );
             peer.remoteDescriptionSet = true;
+            peer.makingOffer = false;
             await this.drainIceQueue(peer);
             const answer = await anyPc.createAnswer();
             await anyPc.setLocalDescription(answer);
@@ -265,8 +270,8 @@ export class GroupAudioManager {
             }
             return;
           }
-          // We have initiative or someone else is already in-flight —
-          // politely ignore this offer. The peer will retry if needed.
+          // We have the smaller userId — our offer wins. Ignore theirs;
+          // they will roll back when they hit this same logic.
           return;
         }
 


### PR DESCRIPTION
Closes #70

## Overview
Replaces the Expo AV file-chunk audio path with WebRTC peer-to-peer Opus audio.

## Files (2 + SPEC_REGISTER)
- `frontend/app/services/groupAudio.ts` (new): 394 lines — GroupAudioManager with STUN-based WebRTC, Opus codec preference, adaptive bitrate 6-24kbps, mic track lifecycle
- `frontend/app/(tabs)/intercom.tsx` (modified): +330 -286 — AAC/Expo AV removal, WebRTC mic track control, peer lifecycle, PTT floor-lock preserved

## Verified unchanged
- `backend/src/services/ws.js` — webrtc_signal relay, ptt_start/ptt_end floor logic intact from PR A
- `frontend/app/services/ws.ts` — typed helpers intact from PR A

## Key decisions
- STUN-only ICE (no TURN in this PR)
- Glare avoidance: lexicographically smaller userId creates offer
- Mic track starts disabled, PTT toggles enabled
- No package/config changes

## Depends on
- PR #69 (WS contracts, webrtc_signal relay) — merged at 3e437ff