### PR TITLE
Issue #72 PR C: intercom always-on mode with signal quality fallback

### DIFF
--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Animated, FlatList, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Animated, AppState, AppStateStatus, FlatList, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFocusEffect } from 'expo-router';
 
-import wsClient, { MemberSnapshotMessage, PresenceMessage, WebRtcSignalMessage } from '../services/ws';
-import { GroupAudioManager } from '../services/groupAudio';
+import wsClient, { MemberSnapshotMessage, PresenceMessage, SignalQuality, WebRtcSignalMessage } from '../services/ws';
+import { GroupAudioManager, GroupAudioMode } from '../services/groupAudio';
 
 interface Identity {
   userId: string;
@@ -17,7 +18,7 @@ interface MemberState {
   isTalking: boolean;
 }
 
-const STORAGE_KEYS = ['userId', 'groupId', 'displayName'] as const;
+const STORAGE_KEYS = ['userId', 'groupId', 'displayName', 'intercomAlwaysOn'] as const;
 
 const IntercomScreen = () => {
   const [identity, setIdentity] = useState<Identity>({ userId: '', groupId: '', name: '' });
@@ -26,6 +27,15 @@ const IntercomScreen = () => {
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'error' | 'closed'>(wsClient.getState());
   const [isTransmitting, setIsTransmitting] = useState(false);
   const [channelBusy, setChannelBusy] = useState(false);
+  const [intercomAlwaysOn, setIntercomAlwaysOn] = useState(false);
+  const [groupAudioMode, setGroupAudioMode] = useState<GroupAudioMode>('ptt');
+  const [fallbackReason, setFallbackReason] = useState<'low_signal' | 'peer_disconnected' | null>(null);
+  const [signalQuality, setSignalQuality] = useState<SignalQuality>({
+    tier: 'poor',
+    rttMs: null,
+    reconnectCount: 0,
+    lastPongAt: null,
+  });
   const [permissionError, setPermissionError] = useState<string | null>(null);
 
   const groupAudioRef = useRef<GroupAudioManager | null>(null);
@@ -76,6 +86,9 @@ const IntercomScreen = () => {
       },
       callbacks: {
         sendSignal: (targetUserId, signal) => wsClient.sendWebRtcSignal(targetUserId, signal),
+        onModeChanged: (mode) => setGroupAudioMode(mode),
+        onFallbackActivated: (reason) => setFallbackReason(reason),
+        onFallbackRecovered: () => setFallbackReason(null),
         onError: (_peerUserId, error) => {
           console.warn('[intercom] group audio error:', error.message);
         },
@@ -84,6 +97,7 @@ const IntercomScreen = () => {
 
     try {
       await manager.start();
+      await manager.setMode(intercomAlwaysOn ? 'always_on' : 'ptt');
       groupAudioRef.current = manager;
       setPermissionError(null);
     } catch (error) {
@@ -91,7 +105,7 @@ const IntercomScreen = () => {
       const message = error instanceof Error ? error.message : String(error);
       setPermissionError(message || 'Unable to access microphone');
     }
-  }, []);
+  }, [intercomAlwaysOn]);
 
   const teardownGroupAudio = useCallback(() => {
     Object.values(recoveryOfferTimersRef.current).forEach((timer) => clearTimeout(timer));
@@ -103,6 +117,7 @@ const IntercomScreen = () => {
   }, []);
 
   const startTalking = useCallback(async () => {
+    if (intercomAlwaysOn && !fallbackReason) return;
     const manager = groupAudioRef.current;
     if (!manager || !groupId || connectionStatus !== 'connected' || isTransmitting || channelBusy) return;
 
@@ -131,7 +146,7 @@ const IntercomScreen = () => {
       const message = error instanceof Error ? error.message : String(error);
       setPermissionError(message || 'Unable to access microphone');
     }
-  }, [channelBusy, connectionStatus, displayName, groupId, isTransmitting, userId]);
+  }, [channelBusy, connectionStatus, displayName, fallbackReason, groupId, intercomAlwaysOn, isTransmitting, userId]);
 
   const stopTalking = useCallback(async () => {
     const manager = groupAudioRef.current;
@@ -326,6 +341,7 @@ const IntercomScreen = () => {
           groupId: (values.groupId as string) || '',
           name: (values.displayName as string) || '',
         });
+        setIntercomAlwaysOn(values.intercomAlwaysOn === 'true');
       } catch (error) {
         console.warn('Failed to load intercom identity', error);
       }
@@ -337,6 +353,22 @@ const IntercomScreen = () => {
       mounted = false;
     };
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+      AsyncStorage.getItem('intercomAlwaysOn')
+        .then((value) => {
+          if (active) {
+            setIntercomAlwaysOn(value === 'true');
+          }
+        })
+        .catch(() => null);
+      return () => {
+        active = false;
+      };
+    }, [])
+  );
 
   useEffect(() => {
     if (!userId || !groupId) return;
@@ -387,6 +419,55 @@ const IntercomScreen = () => {
   }, [handleMessage]);
 
   useEffect(() => {
+    const unsubscribe = wsClient.onSignalQuality((quality) => {
+      setSignalQuality(quality);
+      groupAudioRef.current?.setSignalTier(quality.tier).catch((error) => {
+        console.warn('[intercom] setSignalTier failed:', error);
+      });
+    });
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (intercomAlwaysOn && (isTransmitting || pendingPttRef.current)) {
+      stopTalking().catch(() => null);
+    }
+    const manager = groupAudioRef.current;
+    if (!manager) return;
+
+    const nextMode: GroupAudioMode = intercomAlwaysOn && !fallbackReason ? 'always_on' : 'ptt';
+    manager.setMode(nextMode).catch((error) => {
+      console.warn('[intercom] setMode failed:', error);
+    });
+  }, [fallbackReason, intercomAlwaysOn, isTransmitting, stopTalking]);
+
+  useEffect(() => {
+    const handleAppState = (nextState: AppStateStatus) => {
+      const manager = groupAudioRef.current;
+      if (!manager) return;
+
+      if (nextState !== 'active') {
+        if (isTransmitting || pendingPttRef.current) {
+          stopTalking().catch(() => null);
+        }
+        manager.setMicEnabled(false).catch(() => null);
+        return;
+      }
+
+      if (manager.getMode() === 'always_on') {
+        manager.setMicEnabled(true).catch(() => null);
+      }
+    };
+
+    const subscription = AppState.addEventListener('change', handleAppState);
+    return () => {
+      subscription.remove();
+    };
+  }, [isTransmitting, stopTalking]);
+
+  useEffect(() => {
     let animation: Animated.CompositeAnimation | null = null;
     if (activeSpeaker) {
       animation = Animated.loop(
@@ -405,7 +486,8 @@ const IntercomScreen = () => {
     };
   }, [activeSpeaker, pulseScale]);
 
-  const buttonDisabled = !groupId || connectionStatus !== 'connected';
+  const alwaysOnActive = intercomAlwaysOn && !fallbackReason;
+  const buttonDisabled = !groupId || connectionStatus !== 'connected' || alwaysOnActive;
 
   const memberList = useMemo(() => {
     return Object.values(members).sort((a, b) => {
@@ -417,9 +499,19 @@ const IntercomScreen = () => {
 
   const statusText = groupId
     ? connectionStatus === 'connected'
-      ? 'Connected to group intercom'
+      ? alwaysOnActive
+        ? 'Always-on intercom active'
+        : 'Connected to group intercom'
       : 'Connecting to intercom...'
     : 'Join a group to enable intercom';
+
+  const signalColor = signalQuality.tier === 'excellent'
+    ? '#4caf50'
+    : signalQuality.tier === 'good'
+      ? '#8bc34a'
+      : signalQuality.tier === 'fair'
+        ? '#ffb300'
+        : '#ff7043';
 
   return (
     <View style={styles.container}>
@@ -469,10 +561,28 @@ const IntercomScreen = () => {
       </ScrollView>
 
       <View style={styles.controls}>
+        {fallbackReason ? (
+          <View style={styles.fallbackBanner}>
+            <Text style={styles.fallbackText}>
+              Always-on fallback: {fallbackReason === 'low_signal' ? 'signal is weak' : 'peer link unstable'}.
+            </Text>
+          </View>
+        ) : null}
+        <View style={styles.signalRow}>
+          <View style={[styles.signalDot, { backgroundColor: signalColor }]} />
+          <Text style={styles.signalText}>
+            Signal {signalQuality.tier.toUpperCase()}
+            {signalQuality.rttMs != null ? ` · ${Math.round(signalQuality.rttMs)}ms` : ''}
+            {signalQuality.reconnectCount > 0 ? ` · R${signalQuality.reconnectCount}` : ''}
+          </Text>
+        </View>
         {channelBusy ? (
           <Text style={styles.busyText}>Channel busy — someone else is talking</Text>
         ) : (
-          <Text style={styles.status}>{statusText}</Text>
+          <Text style={styles.status}>
+            {statusText}
+            {groupAudioMode === 'fallback' ? ' (PTT fallback)' : ''}
+          </Text>
         )}
         <Pressable
           onPressIn={startTalking}
@@ -484,7 +594,9 @@ const IntercomScreen = () => {
             buttonDisabled && styles.pttButtonDisabled,
           ]}
         >
-          <Text style={styles.pttLabel}>{isTransmitting ? 'RELEASE TO SEND' : 'HOLD TO TALK'}</Text>
+          <Text style={styles.pttLabel}>
+            {alwaysOnActive ? 'ALWAYS-ON ENABLED' : isTransmitting ? 'RELEASE TO SEND' : 'HOLD TO TALK'}
+          </Text>
         </Pressable>
         {permissionError ? <Text style={styles.errorText}>{permissionError}</Text> : null}
       </View>
@@ -607,6 +719,34 @@ const styles = StyleSheet.create({
     backgroundColor: '#06121f',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: '#1e3a5f',
+  },
+  fallbackBanner: {
+    backgroundColor: '#3f2a18',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#ff9800',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  fallbackText: {
+    color: '#ffd180',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  signalRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  signalDot: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+  signalText: {
+    color: '#9fb4cc',
+    fontSize: 12,
+    fontWeight: '600',
   },
   status: {
     color: '#9fb4cc',

--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -26,6 +26,7 @@ const IntercomScreen = () => {
   const [members, setMembers] = useState<Record<string, MemberState>>({});
   const [activeSpeaker, setActiveSpeaker] = useState<MemberState | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'error' | 'closed'>(wsClient.getState());
+  const [appState, setAppState] = useState<AppStateStatus>(AppState.currentState);
   const [isTransmitting, setIsTransmitting] = useState(false);
   const [channelBusy, setChannelBusy] = useState(false);
   const [intercomAlwaysOn, setIntercomAlwaysOn] = useState(false);
@@ -445,20 +446,19 @@ const IntercomScreen = () => {
   }, []);
 
   useEffect(() => {
-    if (intercomAlwaysOn && (isTransmitting || pendingPttRef.current)) {
-      stopTalking().catch(() => null);
-    }
     const manager = groupAudioRef.current;
     if (!manager) return;
 
-    const nextMode: GroupAudioMode = intercomAlwaysOn ? 'always_on' : 'ptt';
+    const alwaysOnActive = intercomAlwaysOn && !fallbackReason && connectionStatus === 'connected' && appState === 'active';
+    const nextMode: GroupAudioMode = alwaysOnActive ? 'always_on' : 'ptt';
     manager.setMode(nextMode).catch((error) => {
       console.warn('[intercom] setMode failed:', error);
     });
-  }, [fallbackReason, intercomAlwaysOn, isTransmitting, stopTalking]);
+  }, [appState, connectionStatus, fallbackReason, intercomAlwaysOn]);
 
   useEffect(() => {
     const handleAppState = (nextState: AppStateStatus) => {
+      setAppState(nextState);
       const manager = groupAudioRef.current;
       if (!manager) return;
 

--- a/frontend/app/(tabs)/intercom.tsx
+++ b/frontend/app/(tabs)/intercom.tsx
@@ -19,6 +19,7 @@ interface MemberState {
 }
 
 const STORAGE_KEYS = ['userId', 'groupId', 'displayName', 'intercomAlwaysOn'] as const;
+const RECENT_RECONNECT_BADGE_MS = 15_000;
 
 const IntercomScreen = () => {
   const [identity, setIdentity] = useState<Identity>({ userId: '', groupId: '', name: '' });
@@ -41,6 +42,7 @@ const IntercomScreen = () => {
   const groupAudioRef = useRef<GroupAudioManager | null>(null);
   const pendingPttRef = useRef(false);
   const recoveryOfferTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const reconnectBadgeUntilRef = useRef(0);
   const pulseScale = useRef(new Animated.Value(1)).current;
 
   const { userId, groupId, name: displayName } = identity;
@@ -420,7 +422,19 @@ const IntercomScreen = () => {
 
   useEffect(() => {
     const unsubscribe = wsClient.onSignalQuality((quality) => {
-      setSignalQuality(quality);
+      const now = Date.now();
+      setSignalQuality((prev) => {
+        let reconnectCount = quality.reconnectCount;
+        if (quality.reconnectCount > 0) {
+          reconnectBadgeUntilRef.current = now + RECENT_RECONNECT_BADGE_MS;
+        } else if (prev.reconnectCount > 0 && now < reconnectBadgeUntilRef.current) {
+          reconnectCount = prev.reconnectCount;
+        } else {
+          reconnectBadgeUntilRef.current = 0;
+        }
+
+        return { ...quality, reconnectCount };
+      });
       groupAudioRef.current?.setSignalTier(quality.tier).catch((error) => {
         console.warn('[intercom] setSignalTier failed:', error);
       });
@@ -437,7 +451,7 @@ const IntercomScreen = () => {
     const manager = groupAudioRef.current;
     if (!manager) return;
 
-    const nextMode: GroupAudioMode = intercomAlwaysOn && !fallbackReason ? 'always_on' : 'ptt';
+    const nextMode: GroupAudioMode = intercomAlwaysOn ? 'always_on' : 'ptt';
     manager.setMode(nextMode).catch((error) => {
       console.warn('[intercom] setMode failed:', error);
     });
@@ -456,7 +470,7 @@ const IntercomScreen = () => {
         return;
       }
 
-      if (manager.getMode() === 'always_on') {
+      if (manager.getMode() === 'always_on' && !fallbackReason) {
         manager.setMicEnabled(true).catch(() => null);
       }
     };
@@ -465,7 +479,7 @@ const IntercomScreen = () => {
     return () => {
       subscription.remove();
     };
-  }, [isTransmitting, stopTalking]);
+  }, [fallbackReason, isTransmitting, stopTalking]);
 
   useEffect(() => {
     let animation: Animated.CompositeAnimation | null = null;

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -31,6 +31,7 @@ const SettingsScreen = () => {
   const [displayName, setDisplayName] = useState('');
   const [editedName, setEditedName] = useState('');
   const [alwaysOn, setAlwaysOn] = useState(false);
+  const [intercomAlwaysOn, setIntercomAlwaysOn] = useState(false);
   const [saving, setSaving] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -46,11 +47,12 @@ const SettingsScreen = () => {
   useEffect(() => {
     const loadSettings = async () => {
       try {
-        const [[, name], [, alwaysOnVal]] = await AsyncStorage.multiGet(['displayName', 'alwaysOn']);
+        const [[, name], [, alwaysOnVal], [, intercomAlwaysOnVal]] = await AsyncStorage.multiGet(['displayName', 'alwaysOn', 'intercomAlwaysOn']);
         setDisplayName(name || '');
         setEditedName(name || '');
         const running = await isBackgroundLocationRunning();
         setAlwaysOn(running);
+        setIntercomAlwaysOn(intercomAlwaysOnVal === 'true');
         if (alwaysOnVal === 'true' && !running) {
           await AsyncStorage.setItem('alwaysOn', 'false');
         }
@@ -147,6 +149,11 @@ const SettingsScreen = () => {
       setAlwaysOn(false);
       await AsyncStorage.setItem('alwaysOn', 'false');
     }
+  }, []);
+
+  const handleToggleIntercomAlwaysOn = useCallback(async (value: boolean) => {
+    setIntercomAlwaysOn(value);
+    await AsyncStorage.setItem('intercomAlwaysOn', value ? 'true' : 'false');
   }, []);
 
   const handleLeaveGroup = useCallback(() => {
@@ -309,6 +316,20 @@ const SettingsScreen = () => {
             onValueChange={handleToggleAlwaysOn}
             trackColor={{ false: '#26445f', true: '#1e88e5' }}
             thumbColor={alwaysOn ? '#64ffda' : '#9fb4cc'}
+          />
+        </View>
+        <View style={styles.row}>
+          <View>
+            <Text style={styles.rowLabel}>Intercom Always-On</Text>
+            <Text style={styles.rowSub}>
+              {intercomAlwaysOn ? 'Hands-free voice when signal is stable' : 'Push-to-talk intercom mode'}
+            </Text>
+          </View>
+          <Switch
+            value={intercomAlwaysOn}
+            onValueChange={handleToggleIntercomAlwaysOn}
+            trackColor={{ false: '#26445f', true: '#1e88e5' }}
+            thumbColor={intercomAlwaysOn ? '#64ffda' : '#9fb4cc'}
           />
         </View>
       </View>

--- a/frontend/app/services/groupAudio.ts
+++ b/frontend/app/services/groupAudio.ts
@@ -9,6 +9,7 @@ import {
 
 export type SignalTier = 'excellent' | 'good' | 'fair' | 'poor';
 export type AudioBitrateBps = 6000 | 12000 | 18000 | 24000;
+export type GroupAudioMode = 'ptt' | 'always_on' | 'fallback';
 
 export type GroupAudioSignal =
   | { kind: 'offer'; sdp: string }
@@ -31,6 +32,9 @@ export interface GroupAudioCallbacks {
   onRemoteStream?: (peerUserId: string, stream: MediaStream) => void;
   onPeerState?: (peerUserId: string, state: string) => void;
   onSpeakingTrack?: (peerUserId: string, enabled: boolean) => void;
+  onModeChanged?: (mode: GroupAudioMode) => void;
+  onFallbackActivated?: (reason: 'low_signal' | 'peer_disconnected') => void;
+  onFallbackRecovered?: () => void;
   onError?: (peerUserId: string | null, error: Error) => void;
 }
 
@@ -179,6 +183,10 @@ export class GroupAudioManager {
 
   private bitrate: AudioBitrateBps;
 
+  private mode: GroupAudioMode = 'ptt';
+
+  private fallbackActive = false;
+
   private disposed = false;
 
   constructor(options: GroupAudioManagerOptions) {
@@ -315,6 +323,13 @@ export class GroupAudioManager {
   async setSignalTier(tier: SignalTier): Promise<void> {
     this.signalTier = normalizeSignalTier(tier);
     this.bitrate = bitrateForSignalTier(this.signalTier);
+    if (this.mode === 'always_on') {
+      if (this.signalTier === 'poor') {
+        this.setFallbackActive(true, 'low_signal');
+      } else if (this.fallbackActive) {
+        this.setFallbackActive(false);
+      }
+    }
     const peers = Array.from(this.peers.values());
     await Promise.all(peers.map(async (peer) => {
       try {
@@ -327,6 +342,18 @@ export class GroupAudioManager {
 
   getBitrate(): AudioBitrateBps {
     return this.bitrate;
+  }
+
+  getMode(): GroupAudioMode {
+    return this.mode;
+  }
+
+  async setMode(mode: GroupAudioMode): Promise<void> {
+    this.mode = mode;
+    this.callbacks.onModeChanged?.(mode);
+
+    const shouldEnableMic = mode === 'always_on' && !this.fallbackActive;
+    await this.setMicEnabled(shouldEnableMic);
   }
 
   dispose(): void {
@@ -387,6 +414,13 @@ export class GroupAudioManager {
     (pc as any).onconnectionstatechange = () => {
       const state = String((pc as any).connectionState || 'unknown');
       this.callbacks.onPeerState?.(peer.userId, state);
+      if (this.mode === 'always_on') {
+        if (state === 'failed' || state === 'disconnected') {
+          this.setFallbackActive(true, 'peer_disconnected');
+        } else if (state === 'connected' && this.signalTier !== 'poor') {
+          this.setFallbackActive(false);
+        }
+      }
     };
 
     if (this.localStream) {
@@ -422,5 +456,21 @@ export class GroupAudioManager {
   private emitError(peerUserId: string | null, rawError: unknown): void {
     const error = rawError instanceof Error ? rawError : new Error(String(rawError));
     this.callbacks.onError?.(peerUserId, error);
+  }
+
+  private setFallbackActive(active: boolean, reason?: 'low_signal' | 'peer_disconnected'): void {
+    if (this.fallbackActive === active) return;
+    this.fallbackActive = active;
+    if (active) {
+      this.callbacks.onFallbackActivated?.(reason || 'low_signal');
+      this.setMicEnabled(false).catch((error) => this.emitError(null, error));
+      this.callbacks.onModeChanged?.('fallback');
+      return;
+    }
+    this.callbacks.onFallbackRecovered?.();
+    if (this.mode === 'always_on') {
+      this.setMicEnabled(true).catch((error) => this.emitError(null, error));
+      this.callbacks.onModeChanged?.('always_on');
+    }
   }
 }

--- a/frontend/app/services/ws.ts
+++ b/frontend/app/services/ws.ts
@@ -44,11 +44,21 @@ export interface WebRtcSignalMessage {
   signal: any;
 }
 
+export type SignalTier = 'excellent' | 'good' | 'fair' | 'poor';
+
+export interface SignalQuality {
+  tier: SignalTier;
+  rttMs: number | null;
+  reconnectCount: number;
+  lastPongAt: number | null;
+}
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:8100';
 const WS_URL = API_URL.replace('http', 'ws');
 
 const MIN_RECONNECT_DELAY = 1000;
 const MAX_RECONNECT_DELAY = 30000;
+const PING_INTERVAL_MS = 12000;
 
 class FlowWebSocket {
   private socket: WebSocket | null = null;
@@ -57,6 +67,15 @@ class FlowWebSocket {
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelay = MIN_RECONNECT_DELAY;
   private manuallyDisconnected = false;
+  private pingInterval: ReturnType<typeof setInterval> | null = null;
+  private reconnectCount = 0;
+  private lastPongAt: number | null = null;
+  private signalQuality: SignalQuality = {
+    tier: 'poor',
+    rttMs: null,
+    reconnectCount: 0,
+    lastPongAt: null,
+  };
 
   connect(userId: string, groupId: string, name: string) {
     if (!userId || !groupId) return;
@@ -65,6 +84,7 @@ class FlowWebSocket {
     // so the stale async onclose cannot fire a reconnect after we open a new socket (#27, #29)
     this._clearReconnectTimer();
     this.reconnectDelay = MIN_RECONNECT_DELAY;
+    this.reconnectCount = 0;
 
     if (this.socket) {
       this.socket.onclose = null;   // detach old handler — no stale reconnect
@@ -89,13 +109,22 @@ class FlowWebSocket {
 
     this.socket.onopen = () => {
       this.reconnectDelay = MIN_RECONNECT_DELAY;
+      this.reconnectCount = 0;
       this.emit('status', { state: 'connected' });
       this.send({ type: 'join' });
+      this._startPingLoop();
+      this._emitSignalQuality(this.signalQuality.rttMs);
     };
 
     this.socket.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
+        if (data?.type === 'server_pong') {
+          const ts = Number(data?.ts);
+          const rttMs = Number.isFinite(ts) ? Math.max(0, Date.now() - ts) : null;
+          this.lastPongAt = Date.now();
+          this._emitSignalQuality(rttMs);
+        }
         this.emit('message', data);
         if (typeof data?.type === 'string') {
           this.emit(data.type, data);
@@ -112,8 +141,11 @@ class FlowWebSocket {
 
     this.socket.onclose = () => {
       const wasManual = this.manuallyDisconnected;
+      this._clearPingLoop();
       this.emit('status', { state: 'closed' });
       if (!wasManual && this.identity.userId && this.identity.groupId) {
+        this.reconnectCount += 1;
+        this._emitSignalQuality(this.signalQuality.rttMs);
         // Add jitter (±20%) to prevent thundering-herd reconnects (#29)
         const jitter = 0.8 + Math.random() * 0.4;
         const delay = Math.round(this.reconnectDelay * jitter);
@@ -130,6 +162,49 @@ class FlowWebSocket {
       clearTimeout(this.reconnectTimeout);
       this.reconnectTimeout = null;
     }
+  }
+
+  private _startPingLoop() {
+    this._clearPingLoop();
+    this.pingInterval = setInterval(() => {
+      if (this.socket?.readyState === WebSocket.OPEN) {
+        this.sendPing(Date.now());
+      }
+    }, PING_INTERVAL_MS);
+  }
+
+  private _clearPingLoop() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+  }
+
+  private _deriveSignalTier(rttMs: number | null): SignalTier {
+    if (this.socket?.readyState !== WebSocket.OPEN) {
+      return 'poor';
+    }
+    if (this.reconnectCount >= 3) {
+      return 'poor';
+    }
+    if (rttMs == null) {
+      return this.reconnectCount === 0 ? 'good' : 'fair';
+    }
+    if (rttMs <= 140 && this.reconnectCount === 0) return 'excellent';
+    if (rttMs <= 280 && this.reconnectCount <= 1) return 'good';
+    if (rttMs <= 600) return 'fair';
+    return 'poor';
+  }
+
+  private _emitSignalQuality(rttMs: number | null) {
+    const quality: SignalQuality = {
+      tier: this._deriveSignalTier(rttMs),
+      rttMs,
+      reconnectCount: this.reconnectCount,
+      lastPongAt: this.lastPongAt,
+    };
+    this.signalQuality = quality;
+    this.emit('signal_quality', quality);
   }
 
   send(payload: Record<string, any>) {
@@ -161,10 +236,19 @@ class FlowWebSocket {
   disconnect() {
     this.manuallyDisconnected = true;
     this._clearReconnectTimer();
+    this._clearPingLoop();
     if (this.socket) {
       this.socket.close();
       this.socket = null;
     }
+    this.reconnectCount = 0;
+    this.lastPongAt = null;
+    this.signalQuality = {
+      tier: 'poor',
+      rttMs: null,
+      reconnectCount: 0,
+      lastPongAt: null,
+    };
     this.identity = { userId: '', groupId: '', name: '' };
   }
 
@@ -235,6 +319,12 @@ class FlowWebSocket {
 
   sendPing(ts = Date.now()) {
     this.send({ type: 'client_ping', ts });
+  }
+
+  onSignalQuality(handler: (quality: SignalQuality) => void): () => void {
+    return this.on('signal_quality', (payload: any) => {
+      handler(payload as SignalQuality);
+    });
   }
 
   on(event: string, listener: Listener): () => void {


### PR DESCRIPTION
Closes #72

## Summary
- add WS signal-quality tracking (ping/pong RTT + reconnect tracking + tier derivation + event subscription)
- add group-audio mode APIs (setMode/getMode) and fallback callbacks
- add separate intercomAlwaysOn toggle in Settings (kept independent from GPS alwaysOn)
- update Intercom tab to load preference, subscribe to signal quality, run always-on mode, show fallback banner + signal indicator

## Constraints honored
- only touched the 4 scoped frontend files
- no backend/config/package edits
- preserved existing #27/#29 WS reconnect protections
- fallback state is session-local (not persisted)
- always-on mode avoids ptt_start/ptt_end unless fallback is active
- AppState now disables mic when app backgrounds

## Validation
- branch pushed successfully
- local lint execution unavailable in this workspace (frontend eslint binary not installed)