### PR TITLE
feat: mobile EAS build pipeline + fix API URL for ICP block

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,0 +1,59 @@
+name: Build Mobile App
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'EAS build profile'
+        required: true
+        type: choice
+        options:
+          - development
+          - preview
+          - production
+        default: preview
+      platform:
+        description: 'Target platform'
+        required: true
+        type: choice
+        options:
+          - all
+          - android
+          - ios
+        default: all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Expo
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build ${{ inputs.profile }} (${{ inputs.platform }})
+        working-directory: frontend
+        run: |
+          PLATFORM_FLAG=""
+          if [ "${{ inputs.platform }}" != "all" ]; then
+            PLATFORM_FLAG="--platform ${{ inputs.platform }}"
+          fi
+          eas build \
+            --profile ${{ inputs.profile }} \
+            $PLATFORM_FLAG \
+            --non-interactive \
+            --no-wait

--- a/frontend/app/config/api.ts
+++ b/frontend/app/config/api.ts
@@ -1,4 +1,5 @@
-const PRODUCTION_API_URL = 'https://api.wooverse.cn';
+// wooverse.cn blocked by Ali Cloud ICP compliance - using direct IP until ICP resolved
+const PRODUCTION_API_URL = 'http://47.101.222.190:8102';
 const DEVELOPMENT_API_URL = 'http://localhost:8100';
 
 export const EXPO_PUBLIC_API_URL =

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -1,0 +1,62 @@
+{
+  "cli": {
+    "version": ">= 14.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": false
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "http://47.101.222.190:8102",
+        "EXPO_PUBLIC_USE_JPUSH": "true"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": false
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "http://47.101.222.190:8102",
+        "EXPO_PUBLIC_USE_JPUSH": "true"
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "ios": {
+        "appleTeamId": "",
+        "autoIncrement": true
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "http://47.101.222.190:8102",
+        "EXPO_PUBLIC_USE_JPUSH": "true"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft"
+      },
+      "ios": {
+        "appleId": "",
+        "ascAppId": "",
+        "appleTeamId": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **EAS Build config** (`frontend/eas.json`): development, preview, production profiles
- **GitHub Actions** (`.github/workflows/build-mobile.yml`): manual trigger, select profile + platform
- **Fix production API URL**: `http://47.101.222.190:8102` (wooverse.cn blocked by ICP compliance)

## Credentials needed (before first build)
1. `EXPO_TOKEN` GitHub secret — generate at https://expo.dev/settings/access-tokens
2. iOS builds need Apple Team ID in `eas.json`
3. Android signing handled automatically by EAS on first build

## How to build after merge
```bash
# Local:
cd frontend && eas build --profile preview --platform android

# Or via GitHub Actions:
# Actions → Build Mobile App → Run workflow
```

Closes #82