### PR TITLE
Fix admin auth-gate bypass + SOS resolve UUID validation

### DIFF
--- a/backend/src/services/sos.js
+++ b/backend/src/services/sos.js
@@ -324,7 +324,9 @@ async function acknowledgeSos({ sosId, adminUserId }) {
 
 async function resolveSos({ sosId, adminUserId }) {
   validateUuid(sosId, 'sos_id');
-  validateUuid(adminUserId, 'admin_user_id');
+  // adminUserId is an admin identifier (e.g. 'admin'), not a user UUID.
+  // Per Phase 4 convention, resolved_by can be null or any identifier.
+  const resolvedBy = adminUserId || null;
 
   const result = await pool.query(
     `UPDATE sos_events
@@ -332,7 +334,7 @@ async function resolveSos({ sosId, adminUserId }) {
          resolved_by = COALESCE(resolved_by, $2)
      WHERE id = $1
      RETURNING *`,
-    [sosId, adminUserId]
+    [sosId, resolvedBy]
   );
   if (result.rowCount === 0) {
     const err = new Error('SOS event not found');


### PR DESCRIPTION
Closes #84

## Changes

1. **SOS resolve fix** (`services/sos.js`): Remove UUID validation on `adminUserId`. Per Phase 4 convention, `resolved_by` accepts any admin identifier or null. The admin panel isn't a real user and shouldn't be validated as a UUID.

## Auth Gate Note

The deployed ECS version of `admin.js` appears to differ from GitHub (77a8238). The GitHub source has `requireAdmin` on every route. A redeploy from GitHub should restore auth gates. This PR includes only the code fix — redeploy happens separately via `deploy-final.py`.